### PR TITLE
Upgrade jreleaser gradle plugin version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ First, include the `OryHydraDockerComposeContainer` in your project's `build.gra
 [source,groovy]
 ----
 dependencies {
-    testImplementation 'com.ardetrick.testcontainers:ory-hydra-testcontainer:0.0.1'
+    testImplementation 'com.ardetrick.testcontainers:ory-hydra-testcontainer:0.0.2'
 }
 ----
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,17 +1,8 @@
 project:
   name: testcontainers-ory-hydra
-  version: {{projectVersion}}
   description: Testcontainers Ory Hydra integration
   authors:
     - Alex Detrick
-
-release:
-  github:
-    owner: ardetrick
-    name: testcontainers-ory-hydra
-    tagName: v{{projectVersion}}
-    releaseName: Release {{projectVersion}}
-    draft: true
 
 signing:
   active: ALWAYS


### PR DESCRIPTION
- Intended to pull in this fix (https://github.com/jreleaser/jreleaser/issues/1742#event-18133755543) but it doesn't appear to be working. Upgrading anyways.