### PR TITLE
feat: add clientCredentialsFlow() for one-line token minting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/ardetrick/testcontainers-ory-hydra/actions/workflows/gradle.yml/badge.svg)](https://github.com/ardetrick/testcontainers-ory-hydra/actions/workflows/gradle.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-The `OryHydraContainer` is a Testcontainer for the Ory Hydra OAuth 2.0 and OpenID Connect provider. It allows you to quickly integrate and test Ory Hydra functionalities in Java applications — no Docker Compose file required.
+The `OryHydraContainer` is a [Testcontainers](https://testcontainers.com) module for [Ory Hydra](https://www.ory.sh/hydra), the OAuth 2.0 and OpenID Connect provider. It lets you spin up a real Hydra instance in your Java integration tests.
 
 ## Prerequisites
 
@@ -13,6 +13,7 @@ The `OryHydraContainer` is a Testcontainer for the Ory Hydra OAuth 2.0 and OpenI
 
 ## Features
 
+* One-liner token minting — `clientCredentialsFlow()` returns a real token from the running Hydra instance (see [Requesting Tokens](#requesting-tokens)).
 * Zero-config startup — runs database migration and the Hydra server in a single container.
 * Defaults to an in-container SQLite database, so no external database is needed.
 * Automatic setup of Ory Hydra's admin and public ports.
@@ -20,6 +21,7 @@ The `OryHydraContainer` is a Testcontainer for the Ory Hydra OAuth 2.0 and OpenI
 * Convenient methods to fetch base URIs for both the admin and public endpoints.
 * Convenience URI helpers for essential OAuth 2.0 and OpenID Connect endpoints (see [Convenience URI Methods](#convenience-uri-methods)).
 * Customizable through a builder pattern, allowing configuration of the Docker image, environment variables, and wait strategy.
+* Framework-agnostic — plain JDK HTTP under the hood, no framework (or JSON library) dependencies.
 
 ## Usage
 
@@ -69,6 +71,34 @@ try (var hydra = OryHydraContainer.builder().build()) {
 }
 ```
 
+### Requesting Tokens
+
+The flow helper runs against the started container and returns a `FlowResult`, which is either a
+`FlowResult.TokenResponse` (a successful token response, RFC 6749 §5.1) or a `FlowResult.OAuthError`
+(an error response, RFC 6749 §5.2). OAuth protocol errors are returned as values, not thrown;
+transport-level failures throw `HydraFlowException`.
+
+If no client is supplied via `clientId(...)`/`clientSecret(...)`, an ephemeral client with the
+requested scopes is registered automatically — so the shortest path to a real token is one line.
+
+#### Client credentials
+
+```java
+var result = hydra.clientCredentialsFlow()
+        .scopes("read")
+        .execute();
+
+var token = (FlowResult.TokenResponse) result;
+String accessToken = token.accessToken();
+```
+
+#### Wiring your application under test
+
+The library is framework-agnostic: point whatever OAuth/OIDC configuration your application uses
+at the container — `getOpenIdDiscoveryUri()` for discovery-based setups, or
+`publicBaseUriString()`/`getOAuth2TokenUri()` for individual endpoints — and feed it a token minted
+by the flow above.
+
 ### Custom Configuration
 
 ```java
@@ -98,7 +128,7 @@ Using the `Builder` class, you can configure:
 
 ## Creating OAuth2 Clients
 
-Register an OAuth 2.0 client in the running Hydra instance using `createOAuth2Client`. This uses the Hydra CLI inside the container, so no additional HTTP client or dependencies are needed:
+The flow helper in [Requesting Tokens](#requesting-tokens) registers an ephemeral client automatically, so most tests never need to create one explicitly. When a test needs a specific client, register it with `createOAuth2Client`. This uses the Hydra CLI inside the container, so no additional HTTP client or dependencies are needed:
 
 ```java
 hydra.createOAuth2Client("my-client", "my-secret", List.of("http://localhost/callback"));

--- a/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
+++ b/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
@@ -1,5 +1,6 @@
 package com.ardetrick.testcontainers;
 
+import com.ardetrick.testcontainers.oauth2.ClientCredentialsFlow;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
@@ -148,6 +149,19 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
               + "): "
               + result.getStderr());
     }
+  }
+
+  /**
+   * Starts a fluent client-credentials flow (RFC 6749 §4.4) against this container.
+   *
+   * <p>The grant has no end-user, so a successful result never carries an ID token or refresh
+   * token. If no client is supplied, an ephemeral one is created for the request.
+   *
+   * @return a new {@link ClientCredentialsFlow} bound to this container's endpoints
+   */
+  public ClientCredentialsFlow clientCredentialsFlow() {
+    return new ClientCredentialsFlow(
+        URI.create(publicBaseUriString()), URI.create(adminBaseUriString()));
   }
 
   /**

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/AdminClient.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/AdminClient.java
@@ -1,0 +1,38 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+/** Operations against Hydra's admin API used by the OAuth flows. */
+final class AdminClient {
+
+  private final HttpClient http;
+  private final URI adminBaseUri;
+
+  AdminClient(HttpClient http, URI adminBaseUri) {
+    this.http = http;
+    this.adminBaseUri = adminBaseUri;
+  }
+
+  /** Registers an OAuth 2.0 client via {@code POST /admin/clients}. */
+  void createClient(Map<String, Object> registration) {
+    HttpResponse<String> response =
+        Http.send(
+            http,
+            HttpRequest.newBuilder(adminBaseUri.resolve("/admin/clients"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(JsonWriter.write(registration)))
+                .build());
+    if (!Http.is2xx(response.statusCode())) {
+      throw new HydraFlowException(
+          "Failed to create OAuth2 client (HTTP "
+              + response.statusCode()
+              + "): "
+              + response.body());
+    }
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/ClientCredentialsFlow.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/ClientCredentialsFlow.java
@@ -1,0 +1,106 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Drives an OAuth 2.0 client-credentials grant (RFC 6749 §4.4) against Hydra.
+ *
+ * <p>The grant has no end-user, so a successful {@link FlowResult.TokenResponse} never carries an
+ * ID token or refresh token. If no client is supplied via {@link #clientId(String)}, an ephemeral
+ * client is created for the request.
+ */
+public final class ClientCredentialsFlow {
+
+  private final URI publicBaseUri;
+  private final URI adminBaseUri;
+
+  private String clientId;
+  private String clientSecret;
+  private final List<String> scopes = new ArrayList<>();
+
+  /**
+   * Creates a flow bound to a running Hydra container's endpoints.
+   *
+   * @param publicBaseUri the public API base URI
+   * @param adminBaseUri the admin API base URI
+   */
+  public ClientCredentialsFlow(URI publicBaseUri, URI adminBaseUri) {
+    this.publicBaseUri = publicBaseUri;
+    this.adminBaseUri = adminBaseUri;
+  }
+
+  /**
+   * Uses an existing client instead of creating an ephemeral one. Requires {@link
+   * #clientSecret(String)}.
+   *
+   * @param clientId the client identifier
+   * @return this flow
+   */
+  public ClientCredentialsFlow clientId(String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  /**
+   * Sets the secret for the client supplied via {@link #clientId(String)}.
+   *
+   * @param clientSecret the client secret
+   * @return this flow
+   */
+  public ClientCredentialsFlow clientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * Sets the requested scopes (default none).
+   *
+   * @param scopes requested scopes
+   * @return this flow
+   */
+  public ClientCredentialsFlow scopes(String... scopes) {
+    this.scopes.clear();
+    this.scopes.addAll(Arrays.asList(scopes));
+    return this;
+  }
+
+  /**
+   * Runs the flow and returns the result.
+   *
+   * @return a {@link FlowResult.TokenResponse} on success, or a {@link FlowResult.OAuthError} on an
+   *     OAuth error response
+   * @throws HydraFlowException if the request cannot be completed
+   */
+  public FlowResult execute() {
+    if (clientId == null) {
+      createEphemeralClient();
+    } else if (clientSecret == null) {
+      throw new HydraFlowException("clientSecret must be set when clientId is provided");
+    }
+    return TokenEndpointClient.clientCredentials(
+        publicBaseUri.resolve("/oauth2/token"), clientId, clientSecret, scopes);
+  }
+
+  private void createEphemeralClient() {
+    String id = "tc-" + UUID.randomUUID();
+    String secret = UUID.randomUUID().toString();
+    Map<String, Object> registration = new LinkedHashMap<>();
+    registration.put("client_id", id);
+    registration.put("client_secret", secret);
+    registration.put("grant_types", List.of("client_credentials"));
+    registration.put("token_endpoint_auth_method", "client_secret_basic");
+    if (!scopes.isEmpty()) {
+      registration.put("scope", String.join(" ", scopes));
+    }
+    new AdminClient(HttpClient.newHttpClient(), adminBaseUri).createClient(registration);
+    this.clientId = id;
+    this.clientSecret = secret;
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/FlowResult.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/FlowResult.java
@@ -1,0 +1,56 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.util.Map;
+
+/**
+ * Result of a token request against Hydra's token endpoint.
+ *
+ * <p>Models the two outcomes the OAuth 2.0 spec defines at the token endpoint: a successful
+ * response ({@link TokenResponse}, RFC 6749 §5.1) or an error response ({@link OAuthError}, RFC
+ * 6749 §5.2). The distinction is success vs. error, not per-grant, so the same type is returned by
+ * every token helper.
+ */
+public sealed interface FlowResult {
+
+  /**
+   * Successful token response (RFC 6749 §5.1), extended with the OpenID Connect {@code id_token}
+   * (OIDC Core §3.1.3.3).
+   *
+   * <p>Grant-specific absences follow the spec's field-presence constraints rather than introducing
+   * distinct types:
+   *
+   * <ul>
+   *   <li>{@code client_credentials}: {@code idToken} and {@code refreshToken} are always {@code
+   *       null} (no end-user; §4.4.3 omits the refresh token).
+   *   <li>{@code authorization_code}: {@code idToken} is present when the {@code openid} scope was
+   *       requested; {@code refreshToken} when {@code offline}/{@code offline_access} was granted.
+   * </ul>
+   *
+   * @param accessToken the access token (opaque by default, or a JWT when Hydra is configured with
+   *     {@code STRATEGIES_ACCESS_TOKEN=jwt})
+   * @param idToken the OIDC ID token, or {@code null} when not applicable
+   * @param refreshToken the refresh token, or {@code null} when not issued
+   * @param tokenType the token type (typically {@code bearer})
+   * @param expiresInSeconds the access token lifetime in seconds
+   * @param scope the granted scope (space-delimited), or {@code null} if omitted by the server
+   * @param raw the full parsed token response
+   */
+  record TokenResponse(
+      String accessToken,
+      String idToken,
+      String refreshToken,
+      String tokenType,
+      long expiresInSeconds,
+      String scope,
+      Map<String, Object> raw)
+      implements FlowResult {}
+
+  /**
+   * Error response from the token endpoint (RFC 6749 §5.2).
+   *
+   * @param error the RFC 6749 error code (e.g. {@code invalid_client}, {@code invalid_scope})
+   * @param errorDescription human-readable description, or {@code null} if absent
+   * @param errorUri URI with error information, or {@code null} if absent
+   */
+  record OAuthError(String error, String errorDescription, String errorUri) implements FlowResult {}
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/Http.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/Http.java
@@ -1,0 +1,39 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+/** Small HTTP helpers shared by the OAuth flows. */
+final class Http {
+
+  private Http() {}
+
+  static HttpResponse<String> send(HttpClient http, HttpRequest request) {
+    try {
+      return http.send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (IOException e) {
+      throw new HydraFlowException("Request to " + request.uri() + " failed", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new HydraFlowException("Request to " + request.uri() + " was interrupted", e);
+    }
+  }
+
+  static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  static String decode(String value) {
+    return URLDecoder.decode(value, StandardCharsets.UTF_8);
+  }
+
+  /** Returns whether the status code is in the 2xx (success) class. */
+  static boolean is2xx(int statusCode) {
+    return statusCode / 100 == 2;
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/HydraFlowException.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/HydraFlowException.java
@@ -1,0 +1,31 @@
+package com.ardetrick.testcontainers.oauth2;
+
+/**
+ * Thrown when a token request cannot be completed due to a transport- or protocol-level failure (a
+ * network error, an interruption, an unparseable response, or an unexpected response during the
+ * authorization-code flow).
+ *
+ * <p>OAuth 2.0 <em>protocol</em> errors (RFC 6749 §5.2) are not exceptions; they are returned as
+ * {@link FlowResult.OAuthError}.
+ */
+public class HydraFlowException extends RuntimeException {
+
+  /**
+   * Creates a new exception.
+   *
+   * @param message description of the failure
+   */
+  public HydraFlowException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a new exception.
+   *
+   * @param message description of the failure
+   * @param cause underlying cause
+   */
+  public HydraFlowException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/Json.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/Json.java
@@ -1,0 +1,178 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Minimal JSON reader for flat objects (no nested objects or arrays).
+ *
+ * <p>Sufficient for OAuth 2.0 token and error responses, whose members are all primitives. Kept
+ * dependency-free on purpose; richer parsing can be added if a future feature needs nested values.
+ */
+final class Json {
+
+  private final String src;
+  private int pos;
+
+  private Json(String src) {
+    this.src = src;
+  }
+
+  /**
+   * Parses a flat JSON object into an insertion-ordered map.
+   *
+   * @param json the JSON text
+   * @return the parsed members (values are {@link String}, {@link Long}, {@link Double}, {@link
+   *     Boolean}, or {@code null})
+   * @throws JsonParseException if the text is not a flat JSON object
+   */
+  static Map<String, Object> parseObject(String json) {
+    Json parser = new Json(json);
+    parser.skipWhitespace();
+    Map<String, Object> result = parser.object();
+    parser.skipWhitespace();
+    if (parser.pos != parser.src.length()) {
+      throw new JsonParseException("Unexpected trailing content at index " + parser.pos);
+    }
+    return result;
+  }
+
+  private Map<String, Object> object() {
+    expect('{');
+    Map<String, Object> map = new LinkedHashMap<>();
+    skipWhitespace();
+    if (peek() == '}') {
+      pos++;
+      return map;
+    }
+    while (true) {
+      skipWhitespace();
+      String key = readString();
+      skipWhitespace();
+      expect(':');
+      skipWhitespace();
+      map.put(key, readValue());
+      skipWhitespace();
+      char c = nextChar();
+      if (c == '}') {
+        return map;
+      }
+      if (c != ',') {
+        throw new JsonParseException("Expected ',' or '}' at index " + (pos - 1));
+      }
+    }
+  }
+
+  private Object readValue() {
+    char c = peek();
+    return switch (c) {
+      case '"' -> readString();
+      case 't', 'f' -> readBoolean();
+      case 'n' -> readNull();
+      case '{', '[' -> throw new JsonParseException("Nested JSON is not supported at index " + pos);
+      default -> readNumber();
+    };
+  }
+
+  private String readString() {
+    expect('"');
+    StringBuilder sb = new StringBuilder();
+    while (true) {
+      char c = nextChar();
+      if (c == '"') {
+        return sb.toString();
+      }
+      if (c == '\\') {
+        char esc = nextChar();
+        switch (esc) {
+          case '"' -> sb.append('"');
+          case '\\' -> sb.append('\\');
+          case '/' -> sb.append('/');
+          case 'b' -> sb.append('\b');
+          case 'f' -> sb.append('\f');
+          case 'n' -> sb.append('\n');
+          case 'r' -> sb.append('\r');
+          case 't' -> sb.append('\t');
+          case 'u' -> {
+            String hex = src.substring(pos, pos + 4);
+            pos += 4;
+            sb.append((char) Integer.parseInt(hex, 16));
+          }
+          default -> throw new JsonParseException("Invalid escape '\\" + esc + "' at index " + pos);
+        }
+      } else {
+        sb.append(c);
+      }
+    }
+  }
+
+  private Object readNumber() {
+    int start = pos;
+    while (pos < src.length() && "+-0123456789.eE".indexOf(src.charAt(pos)) >= 0) {
+      pos++;
+    }
+    String num = src.substring(start, pos);
+    if (num.isEmpty()) {
+      throw new JsonParseException("Expected value at index " + start);
+    }
+    if (num.indexOf('.') < 0 && num.indexOf('e') < 0 && num.indexOf('E') < 0) {
+      try {
+        return Long.parseLong(num);
+      } catch (NumberFormatException ignored) {
+        // Falls through to double parsing below.
+      }
+    }
+    try {
+      return Double.parseDouble(num);
+    } catch (NumberFormatException e) {
+      throw new JsonParseException("Invalid number '" + num + "' at index " + start);
+    }
+  }
+
+  private Boolean readBoolean() {
+    if (src.startsWith("true", pos)) {
+      pos += 4;
+      return Boolean.TRUE;
+    }
+    if (src.startsWith("false", pos)) {
+      pos += 5;
+      return Boolean.FALSE;
+    }
+    throw new JsonParseException("Invalid literal at index " + pos);
+  }
+
+  private Object readNull() {
+    if (src.startsWith("null", pos)) {
+      pos += 4;
+      return null;
+    }
+    throw new JsonParseException("Invalid literal at index " + pos);
+  }
+
+  private void skipWhitespace() {
+    while (pos < src.length() && Character.isWhitespace(src.charAt(pos))) {
+      pos++;
+    }
+  }
+
+  private char peek() {
+    if (pos >= src.length()) {
+      throw new JsonParseException("Unexpected end of input");
+    }
+    return src.charAt(pos);
+  }
+
+  private char nextChar() {
+    char c = peek();
+    pos++;
+    return c;
+  }
+
+  private void expect(char expected) {
+    char c = nextChar();
+    if (c != expected) {
+      throw new JsonParseException(
+          "Expected '" + expected + "' but found '" + c + "' at index " + (pos - 1));
+    }
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/JsonParseException.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/JsonParseException.java
@@ -1,0 +1,9 @@
+package com.ardetrick.testcontainers.oauth2;
+
+/** Thrown when a JSON response cannot be parsed. */
+class JsonParseException extends RuntimeException {
+
+  JsonParseException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/JsonWriter.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/JsonWriter.java
@@ -1,0 +1,101 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Minimal JSON writer for request bodies.
+ *
+ * <p>Supports the JSON value types needed by Hydra's admin API: {@link Map} (objects), {@link List}
+ * (arrays), {@link String}, {@link Number}, {@link Boolean}, and {@code null}. Kept dependency-free
+ * on purpose, mirroring {@link Json}.
+ */
+final class JsonWriter {
+
+  private JsonWriter() {}
+
+  /**
+   * Serializes a value to JSON.
+   *
+   * @param value the value to serialize
+   * @return the JSON text
+   * @throws IllegalArgumentException if a value of an unsupported type is encountered
+   */
+  static String write(Object value) {
+    StringBuilder sb = new StringBuilder();
+    append(sb, value);
+    return sb.toString();
+  }
+
+  private static void append(StringBuilder sb, Object value) {
+    if (value == null) {
+      sb.append("null");
+    } else if (value instanceof String s) {
+      appendString(sb, s);
+    } else if (value instanceof Boolean b) {
+      sb.append(b);
+    } else if (value instanceof Number n) {
+      sb.append(n);
+    } else if (value instanceof Map<?, ?> map) {
+      appendObject(sb, map);
+    } else if (value instanceof List<?> list) {
+      appendArray(sb, list);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported JSON value type: " + value.getClass().getName());
+    }
+  }
+
+  private static void appendObject(StringBuilder sb, Map<?, ?> map) {
+    sb.append('{');
+    boolean first = true;
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      if (!first) {
+        sb.append(',');
+      }
+      first = false;
+      appendString(sb, String.valueOf(entry.getKey()));
+      sb.append(':');
+      append(sb, entry.getValue());
+    }
+    sb.append('}');
+  }
+
+  private static void appendArray(StringBuilder sb, List<?> list) {
+    sb.append('[');
+    boolean first = true;
+    for (Object item : list) {
+      if (!first) {
+        sb.append(',');
+      }
+      first = false;
+      append(sb, item);
+    }
+    sb.append(']');
+  }
+
+  private static void appendString(StringBuilder sb, String s) {
+    sb.append('"');
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (c) {
+        case '"' -> sb.append("\\\"");
+        case '\\' -> sb.append("\\\\");
+        case '\n' -> sb.append("\\n");
+        case '\r' -> sb.append("\\r");
+        case '\t' -> sb.append("\\t");
+        case '\b' -> sb.append("\\b");
+        case '\f' -> sb.append("\\f");
+        default -> {
+          if (c < 0x20) {
+            sb.append(String.format(Locale.ROOT, "\\u%04x", (int) c));
+          } else {
+            sb.append(c);
+          }
+        }
+      }
+    }
+    sb.append('"');
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
@@ -1,0 +1,76 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import com.ardetrick.testcontainers.oauth2.FlowResult.OAuthError;
+import com.ardetrick.testcontainers.oauth2.FlowResult.TokenResponse;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** Performs requests against Hydra's OAuth 2.0 token endpoint. */
+final class TokenEndpointClient {
+
+  private TokenEndpointClient() {}
+
+  /** Client-credentials grant (RFC 6749 §4.4) using {@code client_secret_basic} authentication. */
+  static FlowResult clientCredentials(
+      URI tokenEndpoint, String clientId, String clientSecret, List<String> scopes) {
+    StringBuilder form = new StringBuilder("grant_type=client_credentials");
+    if (scopes != null && !scopes.isEmpty()) {
+      form.append("&scope=").append(Http.encode(String.join(" ", scopes)));
+    }
+    return post(tokenEndpoint, form.toString(), clientId, clientSecret);
+  }
+
+  private static FlowResult post(
+      URI tokenEndpoint, String form, String clientId, String clientSecret) {
+    String credentials =
+        Base64.getEncoder()
+            .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+    HttpResponse<String> response =
+        Http.send(
+            HttpClient.newHttpClient(),
+            HttpRequest.newBuilder(tokenEndpoint)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Authorization", "Basic " + credentials)
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(form))
+                .build());
+
+    Map<String, Object> json;
+    try {
+      json = Json.parseObject(response.body());
+    } catch (JsonParseException e) {
+      throw new HydraFlowException(
+          "Unparseable token response (HTTP " + response.statusCode() + "): " + response.body(), e);
+    }
+
+    if (Http.is2xx(response.statusCode())) {
+      return new TokenResponse(
+          string(json, "access_token"),
+          string(json, "id_token"),
+          string(json, "refresh_token"),
+          string(json, "token_type"),
+          longValue(json, "expires_in"),
+          string(json, "scope"),
+          Collections.unmodifiableMap(json));
+    }
+    return new OAuthError(
+        string(json, "error"), string(json, "error_description"), string(json, "error_uri"));
+  }
+
+  private static String string(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    return value == null ? null : value.toString();
+  }
+
+  private static long longValue(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    return value instanceof Number number ? number.longValue() : 0L;
+  }
+}

--- a/src/test/java/com/ardetrick/testcontainers/ArchitectureTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/ArchitectureTest.java
@@ -1,9 +1,16 @@
 package com.ardetrick.testcontainers;
 
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.belongToAnyOf;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 
+import com.ardetrick.testcontainers.oauth2.ClientCredentialsFlow;
+import com.ardetrick.testcontainers.oauth2.FlowResult;
+import com.ardetrick.testcontainers.oauth2.HydraFlowException;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -20,4 +27,37 @@ class ArchitectureTest {
 
   @ArchTest
   static final ArchRule no_generic_exceptions = NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+  /**
+   * The oauth2 flows are pure JDK code bound only to a pair of base URIs, so they work against any
+   * Hydra instance and stay unit-testable without Docker. The dependency must remain one-way:
+   * container -> flows, never back.
+   */
+  @ArchTest
+  static final ArchRule oauth2_package_is_independent_of_the_container =
+      noClasses()
+          .that()
+          .resideInAPackage("com.ardetrick.testcontainers.oauth2")
+          .should()
+          .dependOnClassesThat()
+          .resideInAnyPackage(
+              "org.testcontainers..", "com.github.dockerjava..", "com.ardetrick.testcontainers");
+
+  /**
+   * Everything in the oauth2 package other than the flow API is an implementation detail — in
+   * particular the hand-rolled JSON reader/writer, which exists only to keep this library
+   * dependency-free and may be changed or dropped at any time. Package-private visibility keeps
+   * internals out of users' reach.
+   */
+  @ArchTest
+  static final ArchRule oauth2_internals_are_not_public =
+      classes()
+          .that()
+          .resideInAPackage("com.ardetrick.testcontainers.oauth2")
+          .and(
+              not(
+                  belongToAnyOf(
+                      ClientCredentialsFlow.class, FlowResult.class, HydraFlowException.class)))
+          .should()
+          .notBePublic();
 }

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerClientCredentialsTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerClientCredentialsTest.java
@@ -1,0 +1,60 @@
+package com.ardetrick.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ardetrick.testcontainers.oauth2.FlowResult;
+import org.junit.jupiter.api.Test;
+
+public class OryHydraContainerClientCredentialsTest {
+
+  @Test
+  public void clientCredentialsFlowWithEphemeralClientReturnsAccessTokenWithoutUserTokens() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      FlowResult result = container.clientCredentialsFlow().execute();
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      var token = (FlowResult.TokenResponse) result;
+      assertThat(token.accessToken()).isNotBlank();
+      assertThat(token.tokenType()).isEqualToIgnoringCase("bearer");
+      assertThat(token.expiresInSeconds()).isPositive();
+      // client-credentials has no end-user: no ID token, no refresh token.
+      assertThat(token.idToken()).isNull();
+      assertThat(token.refreshToken()).isNull();
+    }
+  }
+
+  @Test
+  public void clientCredentialsFlowWithWrongSecretReturnsOAuthError() throws Exception {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+      var create =
+          container.execInContainer(
+              "hydra",
+              "create",
+              "oauth2-client",
+              "--endpoint",
+              "http://127.0.0.1:4445",
+              "--grant-type",
+              "client_credentials",
+              "--token-endpoint-auth-method",
+              "client_secret_basic",
+              "--id",
+              "cc-known",
+              "--secret",
+              "right-secret");
+      assertThat(create.getExitCode()).isZero();
+
+      FlowResult result =
+          container
+              .clientCredentialsFlow()
+              .clientId("cc-known")
+              .clientSecret("wrong-secret")
+              .execute();
+
+      assertThat(result).isInstanceOf(FlowResult.OAuthError.class);
+      assertThat(((FlowResult.OAuthError) result).error()).isEqualTo("invalid_client");
+    }
+  }
+}

--- a/src/test/java/com/ardetrick/testcontainers/oauth2/JsonTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/oauth2/JsonTest.java
@@ -1,0 +1,52 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class JsonTest {
+
+  @Test
+  void parsesFlatObjectWithMixedValueTypes() {
+    var parsed =
+        Json.parseObject(
+            "{\"access_token\":\"abc\",\"expires_in\":3599,\"scope\":\"read write\","
+                + "\"active\":true,\"missing\":null}");
+
+    assertThat(parsed.get("access_token")).isEqualTo("abc");
+    assertThat(parsed.get("expires_in")).isEqualTo(3599L);
+    assertThat(parsed.get("scope")).isEqualTo("read write");
+    assertThat(parsed.get("active")).isEqualTo(true);
+    assertThat(parsed).containsKey("missing");
+    assertThat(parsed.get("missing")).isNull();
+  }
+
+  @Test
+  void handlesStringEscapesAndUnicode() {
+    var parsed = Json.parseObject("{\"k\":\"a\\\"b\\n\\u0041\"}");
+
+    assertThat(parsed.get("k")).isEqualTo("a\"b\nA");
+  }
+
+  @Test
+  void parsesEmptyObject() {
+    assertThat(Json.parseObject("  {}  ")).isEmpty();
+  }
+
+  @Test
+  void parsesFloatingPointNumber() {
+    assertThat(Json.parseObject("{\"n\":1.5}").get("n")).isEqualTo(1.5d);
+  }
+
+  @Test
+  void rejectsNestedValues() {
+    assertThatThrownBy(() -> Json.parseObject("{\"a\":{\"b\":1}}"))
+        .isInstanceOf(JsonParseException.class);
+  }
+
+  @Test
+  void rejectsTrailingContent() {
+    assertThatThrownBy(() -> Json.parseObject("{} extra")).isInstanceOf(JsonParseException.class);
+  }
+}

--- a/src/test/java/com/ardetrick/testcontainers/oauth2/JsonWriterTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/oauth2/JsonWriterTest.java
@@ -1,0 +1,41 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JsonWriterTest {
+
+  @Test
+  void writesObjectsArraysAndPrimitivesInOrder() {
+    Map<String, Object> object = new LinkedHashMap<>();
+    object.put("s", "a\"b");
+    object.put("n", 3);
+    object.put("flag", true);
+    object.put("nothing", null);
+    object.put("list", List.of("x", "y"));
+
+    assertThat(JsonWriter.write(object))
+        .isEqualTo(
+            "{\"s\":\"a\\\"b\",\"n\":3,\"flag\":true,\"nothing\":null,\"list\":[\"x\",\"y\"]}");
+  }
+
+  @Test
+  void writesNestedObjects() {
+    Map<String, Object> session = new LinkedHashMap<>();
+    session.put("access_token", Map.of("email", "u@example.com"));
+
+    assertThat(JsonWriter.write(session))
+        .isEqualTo("{\"access_token\":{\"email\":\"u@example.com\"}}");
+  }
+
+  @Test
+  void rejectsUnsupportedValueTypes() {
+    assertThatThrownBy(() -> JsonWriter.write(Map.of("x", new Object())))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
Adds a fluent client-credentials flow helper that mints a real access token from the running Hydra instance, auto-registering an ephemeral client when none is supplied. OAuth protocol errors are returned as FlowResult.OAuthError values; transport failures throw HydraFlowException. The oauth2 package is pure JDK code, kept independent of the container and Docker by new ArchUnit rules that also lock internals (including the hand-rolled JSON reader/writer) to package-private.