### PR TITLE
feat: add authorizationCodeFlow() with automatic login/consent handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The `OryHydraContainer` is a [Testcontainers](https://testcontainers.com) module
 
 ## Features
 
-* One-liner token minting — `clientCredentialsFlow()` returns a real token from the running Hydra instance (see [Requesting Tokens](#requesting-tokens)).
+* One-liner token minting — `authorizationCodeFlow()` and `clientCredentialsFlow()` return real tokens from the running Hydra instance (see [Requesting Tokens](#requesting-tokens)).
+* Full authorization-code flow without a browser or a login/consent app — the flow driver answers Hydra's login and consent challenges through the admin API, with configurable subject, scopes, audience, session claims, PKCE, and denial modes.
 * Zero-config startup — runs database migration and the Hydra server in a single container.
 * Defaults to an in-container SQLite database, so no external database is needed.
 * Automatic setup of Ory Hydra's admin and public ports.
@@ -73,7 +74,7 @@ try (var hydra = OryHydraContainer.builder().build()) {
 
 ### Requesting Tokens
 
-The flow helper runs against the started container and returns a `FlowResult`, which is either a
+Both flow helpers run against the started container and return a `FlowResult`, which is either a
 `FlowResult.TokenResponse` (a successful token response, RFC 6749 §5.1) or a `FlowResult.OAuthError`
 (an error response, RFC 6749 §5.2). OAuth protocol errors are returned as values, not thrown;
 transport-level failures throw `HydraFlowException`.
@@ -81,7 +82,49 @@ transport-level failures throw `HydraFlowException`.
 If no client is supplied via `clientId(...)`/`clientSecret(...)`, an ephemeral client with the
 requested scopes is registered automatically — so the shortest path to a real token is one line.
 
+#### Authorization code — no browser, no login/consent app required
+
+Ory Hydra normally delegates login and consent to an app you provide, which makes the
+authorization-code flow notoriously hard to integration-test. The flow driver removes that
+requirement: it performs the real authorization-code exchange against Hydra, following each
+redirect manually and answering the login and consent challenges through Hydra's admin API —
+asserting the subject you configure and granting the requested scopes.
+
+```java
+var result = hydra.authorizationCodeFlow()
+        .scopes("openid", "offline_access")
+        .subject("user-123")
+        .claims(Map.of("email", "user-123@example.com"))
+        .execute();
+
+var token = (FlowResult.TokenResponse) result;
+String accessToken  = token.accessToken();
+String idToken      = token.idToken();      // present because "openid" was granted
+String refreshToken = token.refreshToken(); // present because "offline_access" was granted
+```
+
+Options: `audience(...)` requests token audiences; `accessTokenClaims(...)`/`idTokenClaims(...)`
+target one token's session claims instead of both; `usePkce(true)` enables PKCE with the S256
+method.
+
+Because the tokens come from a real Hydra instance, denial paths are real too — a rejected consent
+produces Hydra's actual error redirect, not a fabricated response:
+
+```java
+var error = (FlowResult.OAuthError) hydra.authorizationCodeFlow()
+        .rejectConsent("access_denied", "user declined")
+        .execute();
+// error.error() == "access_denied"
+```
+
+To exercise a specific pre-registered client instead of an ephemeral one, pass
+`clientId(...)`/`clientSecret(...)`. The flow currently uses the fixed redirect URI
+`http://localhost/callback` (never actually served), so a pre-registered client must include that
+value in its `redirect_uris`.
+
 #### Client credentials
+
+For machine-to-machine tokens with no end-user, the client-credentials grant is the quickest path:
 
 ```java
 var result = hydra.clientCredentialsFlow()
@@ -94,10 +137,10 @@ String accessToken = token.accessToken();
 
 #### Testing a real login/consent app
 
-Hydra delegates login and consent to an app you provide. If the thing you are testing *is* that
-app, point `urlsLogin(...)`/`urlsConsent(...)` at it and drive the authorization-code flow
-externally (typically with a browser automation tool), letting your app answer Hydra's challenges
-via the admin API as it would in production. See
+The flow driver above replaces the login/consent app so you don't have to write one. If the thing
+you are testing *is* your login/consent app, don't use it — point `urlsLogin(...)`/`urlsConsent(...)`
+at your app and drive the flow externally (typically with a browser automation tool), letting your
+app answer Hydra's challenges via the admin API as it would in production. See
 [ory-hydra-refrence-java](https://github.com/ardetrick/ory-hydra-refrence-java) for a complete
 reference implementation of a login/consent app tested with this library.
 
@@ -106,7 +149,7 @@ reference implementation of a login/consent app tested with this library.
 The library is framework-agnostic: point whatever OAuth/OIDC configuration your application uses
 at the container — `getOpenIdDiscoveryUri()` for discovery-based setups, or
 `publicBaseUriString()`/`getOAuth2TokenUri()` for individual endpoints — and feed it a token minted
-by the flow above.
+by one of the flows above.
 
 ### Custom Configuration
 
@@ -125,8 +168,8 @@ var hydra = OryHydraContainer.builder()
 Using the `Builder` class, you can configure:
 
 * `image(DockerImageName)`: Override the Docker image (default: `oryd/hydra:v25.4.0`).
-* `urlsLogin(String)`: Set the login URL (`URLS_LOGIN`).
-* `urlsConsent(String)`: Set the consent URL (`URLS_CONSENT`).
+* `urlsLogin(String)`: Set the login URL (`URLS_LOGIN`). Defaults to a non-resolvable sentinel host; the authorization-code flow helper intercepts login redirects by their challenge parameter, so the sentinel is never contacted.
+* `urlsConsent(String)`: Set the consent URL (`URLS_CONSENT`). Defaults to a non-resolvable sentinel host, as above.
 * `urlsSelfIssuer(String)`: Set the self-issuer URL (`URLS_SELF_ISSUER`).
 * `urlsLogout(String)`: Set the logout URL (`URLS_LOGOUT`).
 * `secretsSystem(String)`: Set the system secret used for encryption (`SECRETS_SYSTEM`).
@@ -137,7 +180,7 @@ Using the `Builder` class, you can configure:
 
 ## Creating OAuth2 Clients
 
-The flow helper in [Requesting Tokens](#requesting-tokens) registers an ephemeral client automatically, so most tests never need to create one explicitly. When a test needs a specific client, register it with `createOAuth2Client`. This uses the Hydra CLI inside the container, so no additional HTTP client or dependencies are needed:
+The flow helpers in [Requesting Tokens](#requesting-tokens) register an ephemeral client automatically, so most tests never need to create one explicitly. When a test needs a specific client, register it with `createOAuth2Client`. This uses the Hydra CLI inside the container, so no additional HTTP client or dependencies are needed:
 
 ```java
 hydra.createOAuth2Client("my-client", "my-secret", List.of("http://localhost/callback"));

--- a/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
+++ b/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
@@ -1,5 +1,6 @@
 package com.ardetrick.testcontainers;
 
+import com.ardetrick.testcontainers.oauth2.AuthorizationCodeFlow;
 import com.ardetrick.testcontainers.oauth2.ClientCredentialsFlow;
 import java.io.IOException;
 import java.net.URI;
@@ -28,6 +29,10 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
   static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("oryd/hydra:v25.4.0");
   static final String DEFAULT_DSN = "sqlite:///tmp/db.sqlite?_fk=true";
   static final String DEFAULT_SECRETS_SYSTEM = "testcontainers-ory-hydra-secret";
+  // Non-resolvable sentinels: the authorization-code flow intercepts the login/consent redirects by
+  // their challenge query parameter, so these hosts are never actually contacted.
+  static final String DEFAULT_URLS_LOGIN = "http://hydra-login.invalid/login";
+  static final String DEFAULT_URLS_CONSENT = "http://hydra-consent.invalid/consent";
   static final WaitStrategy DEFAULT_WAIT_STRATEGY =
       Wait.forHttp("/health/ready")
           .forPort(HYDRA_ADMIN_PORT)
@@ -165,6 +170,23 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
   }
 
   /**
+   * Starts a fluent authorization-code flow against this container.
+   *
+   * <p>The flow auto-accepts (or, on request, rejects) Hydra's login and consent challenges via the
+   * admin API, so a real token can be obtained without a browser or a user-written login/consent
+   * app. Login and consent redirects are intercepted by their challenge query parameter, not by
+   * host, so the configured {@code URLS_LOGIN}/{@code URLS_CONSENT} values (non-resolvable
+   * sentinels by default) are never contacted — the flow also works when they are overridden via
+   * {@link Builder#urlsLogin(String)} / {@link Builder#urlsConsent(String)}.
+   *
+   * @return a new {@link AuthorizationCodeFlow} bound to this container's endpoints
+   */
+  public AuthorizationCodeFlow authorizationCodeFlow() {
+    return new AuthorizationCodeFlow(
+        URI.create(publicBaseUriString()), URI.create(adminBaseUriString()));
+  }
+
+  /**
    * Builds a convenience link to the OpenID Connect discovery endpoint.
    *
    * @return absolute URI pointing to {@code /.well-known/openid-configuration} on the public
@@ -197,6 +219,8 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
     public Builder() {
       env.put("DSN", DEFAULT_DSN);
       env.put("SECRETS_SYSTEM", DEFAULT_SECRETS_SYSTEM);
+      env.put("URLS_LOGIN", DEFAULT_URLS_LOGIN);
+      env.put("URLS_CONSENT", DEFAULT_URLS_CONSENT);
     }
 
     /**

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/AdminClient.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/AdminClient.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /** Operations against Hydra's admin API used by the OAuth flows. */
@@ -34,5 +36,85 @@ final class AdminClient {
               + "): "
               + response.body());
     }
+  }
+
+  URI acceptLogin(String challenge, String subject) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("subject", subject);
+    body.put("remember", false);
+    body.put("remember_for", 0);
+    return redirectTarget(put("login", "accept", "login_challenge", challenge, body));
+  }
+
+  URI rejectLogin(String challenge, String error, String description) {
+    return redirectTarget(
+        put("login", "reject", "login_challenge", challenge, errorBody(error, description)));
+  }
+
+  URI acceptConsent(
+      String challenge,
+      List<String> grantScope,
+      List<String> grantAudience,
+      Map<String, Object> session) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("grant_scope", grantScope);
+    body.put("grant_access_token_audience", grantAudience);
+    body.put("remember", false);
+    body.put("remember_for", 0);
+    if (session != null && !session.isEmpty()) {
+      body.put("session", session);
+    }
+    return redirectTarget(put("consent", "accept", "consent_challenge", challenge, body));
+  }
+
+  URI rejectConsent(String challenge, String error, String description) {
+    return redirectTarget(
+        put("consent", "reject", "consent_challenge", challenge, errorBody(error, description)));
+  }
+
+  private HttpResponse<String> put(
+      String flow, String action, String param, String challenge, Map<String, Object> body) {
+    URI uri =
+        adminBaseUri.resolve(
+            "/admin/oauth2/auth/requests/"
+                + flow
+                + "/"
+                + action
+                + "?"
+                + param
+                + "="
+                + Http.encode(challenge));
+    return Http.send(
+        http,
+        HttpRequest.newBuilder(uri)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .PUT(HttpRequest.BodyPublishers.ofString(JsonWriter.write(body)))
+            .build());
+  }
+
+  private static Map<String, Object> errorBody(String error, String description) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("error", error);
+    body.put("error_description", description == null ? "" : description);
+    return body;
+  }
+
+  private static URI redirectTarget(HttpResponse<String> response) {
+    if (!Http.is2xx(response.statusCode())) {
+      throw new HydraFlowException(
+          "Admin request failed (HTTP " + response.statusCode() + "): " + response.body());
+    }
+    Map<String, Object> json;
+    try {
+      json = Json.parseObject(response.body());
+    } catch (JsonParseException e) {
+      throw new HydraFlowException("Unparseable admin response: " + response.body(), e);
+    }
+    Object redirect = json.get("redirect_to");
+    if (redirect == null) {
+      throw new HydraFlowException("Admin response missing redirect_to: " + response.body());
+    }
+    return URI.create(redirect.toString());
   }
 }

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
@@ -1,0 +1,394 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import com.ardetrick.testcontainers.oauth2.FlowResult.OAuthError;
+import java.net.CookieManager;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Drives a full OAuth 2.0 authorization-code flow against Hydra, auto-accepting (or rejecting) the
+ * login and consent challenges via Hydra's admin API — returning a real token without a browser or
+ * a user-written login/consent app.
+ *
+ * <p>The flow follows redirects manually (no embedded server), short-circuiting the login/consent
+ * hops by calling the admin API directly and rewriting each Hydra-bound redirect to the container's
+ * mapped host and port. Hydra's redirects carry its configured issuer, which cannot know the
+ * dynamically mapped port; rewriting each hop means nothing needs the issuer to be externally
+ * reachable, so no fixed ports and no post-start reconfiguration — safe for parallel test runs.
+ */
+public final class AuthorizationCodeFlow {
+
+  private static final String REDIRECT_URI = "http://localhost/callback";
+  private static final int MAX_HOPS = 10;
+
+  private final URI publicBaseUri;
+  private final URI adminBaseUri;
+
+  private String clientId;
+  private String clientSecret;
+  private List<String> scopes = new ArrayList<>(List.of("openid"));
+  private String subject = "test-subject";
+  private final List<String> audience = new ArrayList<>();
+  private final Map<String, Object> accessTokenClaims = new LinkedHashMap<>();
+  private final Map<String, Object> idTokenClaims = new LinkedHashMap<>();
+  private String rejectLoginError;
+  private String rejectLoginDescription;
+  private String rejectConsentError;
+  private String rejectConsentDescription;
+  private boolean usePkce = false;
+
+  /**
+   * Creates a flow bound to a running Hydra container's endpoints.
+   *
+   * @param publicBaseUri the public API base URI
+   * @param adminBaseUri the admin API base URI
+   */
+  public AuthorizationCodeFlow(URI publicBaseUri, URI adminBaseUri) {
+    this.publicBaseUri = publicBaseUri;
+    this.adminBaseUri = adminBaseUri;
+  }
+
+  /**
+   * Uses an existing client instead of creating an ephemeral one. Requires {@link
+   * #clientSecret(String)}.
+   *
+   * <p>The flow uses the fixed redirect URI {@code http://localhost/callback} (never actually
+   * served), so the client must include it in its registered {@code redirect_uris}.
+   *
+   * @param clientId the client identifier
+   * @return this flow
+   */
+  public AuthorizationCodeFlow clientId(String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  /**
+   * Sets the secret for the client supplied via {@link #clientId(String)}.
+   *
+   * @param clientSecret the client secret
+   * @return this flow
+   */
+  public AuthorizationCodeFlow clientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * Sets the requested scopes (default {@code openid}).
+   *
+   * @param scopes requested scopes
+   * @return this flow
+   */
+  public AuthorizationCodeFlow scopes(String... scopes) {
+    this.scopes = new ArrayList<>(Arrays.asList(scopes));
+    return this;
+  }
+
+  /**
+   * Sets the subject the auto-accepted login asserts (default {@code test-subject}).
+   *
+   * @param subject the authenticated subject
+   * @return this flow
+   */
+  public AuthorizationCodeFlow subject(String subject) {
+    this.subject = subject;
+    return this;
+  }
+
+  /**
+   * Sets the requested token audience.
+   *
+   * @param audience requested audience values
+   * @return this flow
+   */
+  public AuthorizationCodeFlow audience(String... audience) {
+    this.audience.clear();
+    this.audience.addAll(Arrays.asList(audience));
+    return this;
+  }
+
+  /**
+   * Adds claims to both the access token and ID token sessions.
+   *
+   * @param claims claims to add
+   * @return this flow
+   */
+  public AuthorizationCodeFlow claims(Map<String, Object> claims) {
+    this.accessTokenClaims.putAll(claims);
+    this.idTokenClaims.putAll(claims);
+    return this;
+  }
+
+  /**
+   * Adds claims to the access token session only.
+   *
+   * @param claims claims to add
+   * @return this flow
+   */
+  public AuthorizationCodeFlow accessTokenClaims(Map<String, Object> claims) {
+    this.accessTokenClaims.putAll(claims);
+    return this;
+  }
+
+  /**
+   * Adds claims to the ID token session only.
+   *
+   * @param claims claims to add
+   * @return this flow
+   */
+  public AuthorizationCodeFlow idTokenClaims(Map<String, Object> claims) {
+    this.idTokenClaims.putAll(claims);
+    return this;
+  }
+
+  /**
+   * Rejects the login challenge instead of accepting it, producing an error response.
+   *
+   * @param error the OAuth error code
+   * @param description a human-readable description
+   * @return this flow
+   */
+  public AuthorizationCodeFlow rejectLogin(String error, String description) {
+    this.rejectLoginError = error;
+    this.rejectLoginDescription = description;
+    return this;
+  }
+
+  /**
+   * Rejects the consent challenge instead of accepting it, producing an error response.
+   *
+   * @param error the OAuth error code
+   * @param description a human-readable description
+   * @return this flow
+   */
+  public AuthorizationCodeFlow rejectConsent(String error, String description) {
+    this.rejectConsentError = error;
+    this.rejectConsentDescription = description;
+    return this;
+  }
+
+  /**
+   * Enables PKCE (RFC 7636) with the {@code S256} method (default disabled).
+   *
+   * @param enabled whether to use PKCE
+   * @return this flow
+   */
+  public AuthorizationCodeFlow usePkce(boolean enabled) {
+    this.usePkce = enabled;
+    return this;
+  }
+
+  /**
+   * Runs the flow and returns the result.
+   *
+   * @return a {@link FlowResult.TokenResponse} on success, or a {@link OAuthError} if Hydra
+   *     returned an OAuth error (e.g. from a rejected login/consent)
+   * @throws HydraFlowException if the flow cannot be completed
+   */
+  public FlowResult execute() {
+    HttpClient http =
+        HttpClient.newBuilder()
+            .cookieHandler(new CookieManager())
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+    AdminClient admin = new AdminClient(http, adminBaseUri);
+
+    resolveClient(admin);
+
+    String state = UUID.randomUUID().toString();
+    String codeVerifier = usePkce ? randomUrlSafe() : null;
+    URI current = buildAuthorizeUri(state, codeVerifier == null ? null : s256(codeVerifier));
+
+    // Each hop is one of: an OAuth error, a login/consent challenge to answer via the admin API,
+    // the client callback carrying the code, or another Hydra-bound redirect to follow.
+    for (int hop = 0; hop < MAX_HOPS; hop++) {
+      URI location = followRedirect(http, current);
+      Map<String, String> query = parseQuery(location.getRawQuery());
+
+      if (query.containsKey("error")) {
+        return new OAuthError(
+            query.get("error"), query.get("error_description"), query.get("error_uri"));
+      }
+      if (query.containsKey("login_challenge")) {
+        current = rewrite(answerLogin(admin, query.get("login_challenge")));
+      } else if (query.containsKey("consent_challenge")) {
+        current = rewrite(answerConsent(admin, query.get("consent_challenge")));
+      } else if (isRedirectUri(location)) {
+        return exchangeCode(query, state, codeVerifier);
+      } else {
+        current = rewrite(location);
+      }
+    }
+
+    throw new HydraFlowException(
+        "Authorization code not received within " + MAX_HOPS + " redirects");
+  }
+
+  private static URI followRedirect(HttpClient http, URI current) {
+    HttpResponse<String> response = Http.send(http, HttpRequest.newBuilder(current).GET().build());
+    if (!Http.is3xx(response.statusCode())) {
+      throw new HydraFlowException(
+          "Unexpected non-redirect response (HTTP "
+              + response.statusCode()
+              + ") during authorization flow: "
+              + response.body());
+    }
+    return current.resolve(
+        response
+            .headers()
+            .firstValue("location")
+            .orElseThrow(
+                () -> new HydraFlowException("Redirect response without Location header")));
+  }
+
+  private URI answerLogin(AdminClient admin, String challenge) {
+    return rejectLoginError != null
+        ? admin.rejectLogin(challenge, rejectLoginError, rejectLoginDescription)
+        : admin.acceptLogin(challenge, subject);
+  }
+
+  private URI answerConsent(AdminClient admin, String challenge) {
+    return rejectConsentError != null
+        ? admin.rejectConsent(challenge, rejectConsentError, rejectConsentDescription)
+        : admin.acceptConsent(
+            challenge, new ArrayList<>(scopes), new ArrayList<>(audience), session());
+  }
+
+  private FlowResult exchangeCode(Map<String, String> query, String state, String codeVerifier) {
+    if (!state.equals(query.get("state"))) {
+      throw new HydraFlowException("State mismatch in authorization response");
+    }
+    String code = query.get("code");
+    if (code == null) {
+      throw new HydraFlowException("Authorization response contains neither code nor error");
+    }
+    return TokenEndpointClient.authorizationCode(
+        publicBaseUri.resolve("/oauth2/token"),
+        clientId,
+        clientSecret,
+        code,
+        REDIRECT_URI,
+        codeVerifier);
+  }
+
+  private void resolveClient(AdminClient admin) {
+    if (clientId != null) {
+      if (clientSecret == null) {
+        throw new HydraFlowException("clientSecret must be set when clientId is provided");
+      }
+      return;
+    }
+    String id = "tc-" + UUID.randomUUID();
+    String secret = UUID.randomUUID().toString();
+    Map<String, Object> registration = new LinkedHashMap<>();
+    registration.put("client_id", id);
+    registration.put("client_secret", secret);
+    registration.put("grant_types", List.of("authorization_code", "refresh_token"));
+    registration.put("response_types", List.of("code"));
+    registration.put("redirect_uris", List.of(REDIRECT_URI));
+    registration.put("scope", String.join(" ", scopes));
+    registration.put("token_endpoint_auth_method", "client_secret_basic");
+    if (!audience.isEmpty()) {
+      registration.put("audience", new ArrayList<>(audience));
+    }
+    admin.createClient(registration);
+    this.clientId = id;
+    this.clientSecret = secret;
+  }
+
+  private Map<String, Object> session() {
+    Map<String, Object> session = new LinkedHashMap<>();
+    if (!accessTokenClaims.isEmpty()) {
+      session.put("access_token", accessTokenClaims);
+    }
+    if (!idTokenClaims.isEmpty()) {
+      session.put("id_token", idTokenClaims);
+    }
+    return session;
+  }
+
+  private URI buildAuthorizeUri(String state, String codeChallenge) {
+    StringBuilder query = new StringBuilder();
+    query.append("client_id=").append(Http.encode(clientId));
+    query.append("&response_type=code");
+    query.append("&redirect_uri=").append(Http.encode(REDIRECT_URI));
+    query.append("&scope=").append(Http.encode(String.join(" ", scopes)));
+    query.append("&state=").append(Http.encode(state));
+    for (String aud : audience) {
+      query.append("&audience=").append(Http.encode(aud));
+    }
+    if (codeChallenge != null) {
+      query.append("&code_challenge=").append(Http.encode(codeChallenge));
+      query.append("&code_challenge_method=S256");
+    }
+    return publicBaseUri.resolve("/oauth2/auth?" + query);
+  }
+
+  private boolean isRedirectUri(URI location) {
+    URI redirect = URI.create(REDIRECT_URI);
+    return redirect.getHost().equals(location.getHost())
+        && redirect.getPath().equals(location.getPath());
+  }
+
+  private URI rewrite(URI location) {
+    try {
+      return new URI(
+          publicBaseUri.getScheme(),
+          null,
+          publicBaseUri.getHost(),
+          publicBaseUri.getPort(),
+          location.getPath(),
+          location.getQuery(),
+          location.getFragment());
+    } catch (URISyntaxException e) {
+      throw new HydraFlowException("Failed to rewrite redirect URI: " + location, e);
+    }
+  }
+
+  private static Map<String, String> parseQuery(String rawQuery) {
+    Map<String, String> map = new LinkedHashMap<>();
+    if (rawQuery == null || rawQuery.isEmpty()) {
+      return map;
+    }
+    for (String pair : rawQuery.split("&")) {
+      int idx = pair.indexOf('=');
+      if (idx < 0) {
+        map.put(Http.decode(pair), "");
+      } else {
+        map.put(Http.decode(pair.substring(0, idx)), Http.decode(pair.substring(idx + 1)));
+      }
+    }
+    return map;
+  }
+
+  private static String randomUrlSafe() {
+    byte[] buffer = new byte[64];
+    new SecureRandom().nextBytes(buffer);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(buffer);
+  }
+
+  private static String s256(String verifier) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(verifier.getBytes(StandardCharsets.US_ASCII));
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    } catch (NoSuchAlgorithmException e) {
+      throw new HydraFlowException("SHA-256 is not available", e);
+    }
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
@@ -27,6 +27,23 @@ final class TokenEndpointClient {
     return post(tokenEndpoint, form.toString(), clientId, clientSecret);
   }
 
+  /** Authorization-code exchange (RFC 6749 §4.1.3) using {@code client_secret_basic}. */
+  static FlowResult authorizationCode(
+      URI tokenEndpoint,
+      String clientId,
+      String clientSecret,
+      String code,
+      String redirectUri,
+      String codeVerifier) {
+    StringBuilder form = new StringBuilder("grant_type=authorization_code");
+    form.append("&code=").append(Http.encode(code));
+    form.append("&redirect_uri=").append(Http.encode(redirectUri));
+    if (codeVerifier != null) {
+      form.append("&code_verifier=").append(Http.encode(codeVerifier));
+    }
+    return post(tokenEndpoint, form.toString(), clientId, clientSecret);
+  }
+
   private static FlowResult post(
       URI tokenEndpoint, String form, String clientId, String clientSecret) {
     String credentials =

--- a/src/test/java/com/ardetrick/testcontainers/ArchitectureTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/ArchitectureTest.java
@@ -8,6 +8,7 @@ import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 
+import com.ardetrick.testcontainers.oauth2.AuthorizationCodeFlow;
 import com.ardetrick.testcontainers.oauth2.ClientCredentialsFlow;
 import com.ardetrick.testcontainers.oauth2.FlowResult;
 import com.ardetrick.testcontainers.oauth2.HydraFlowException;
@@ -57,7 +58,10 @@ class ArchitectureTest {
           .and(
               not(
                   belongToAnyOf(
-                      ClientCredentialsFlow.class, FlowResult.class, HydraFlowException.class)))
+                      AuthorizationCodeFlow.class,
+                      ClientCredentialsFlow.class,
+                      FlowResult.class,
+                      HydraFlowException.class)))
           .should()
           .notBePublic();
 }

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
@@ -1,0 +1,177 @@
+package com.ardetrick.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ardetrick.testcontainers.oauth2.FlowResult;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class OryHydraContainerAuthorizationCodeFlowTest {
+
+  @Test
+  public void authorizationCodeFlowReturnsUsableTokensCarryingSubjectAndClaims() throws Exception {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      FlowResult result =
+          container
+              .authorizationCodeFlow()
+              .scopes("openid", "offline_access")
+              .subject("user-123")
+              .claims(Map.of("email", "user-123@example.com"))
+              .execute();
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      var token = (FlowResult.TokenResponse) result;
+      assertThat(token.accessToken()).isNotBlank();
+      assertThat(token.idToken()).isNotBlank(); // openid scope granted
+      assertThat(token.refreshToken()).isNotBlank(); // offline_access granted
+      assertThat(token.tokenType()).isEqualToIgnoringCase("bearer");
+
+      // The configured subject and claims must actually land in the ID token.
+      var idTokenPayload =
+          new String(
+              Base64.getUrlDecoder().decode(token.idToken().split("\\.")[1]),
+              StandardCharsets.UTF_8);
+      assertThat(idTokenPayload).contains("\"sub\":\"user-123\"");
+      assertThat(idTokenPayload).contains("\"email\":\"user-123@example.com\"");
+
+      // The access token must be usable: Hydra's introspection endpoint reports it active,
+      // attributed to the configured subject — what a resource server under test would see.
+      var introspection =
+          HttpClient.newHttpClient()
+              .send(
+                  HttpRequest.newBuilder(
+                          URI.create(container.adminBaseUriString() + "/admin/oauth2/introspect"))
+                      .header("Content-Type", "application/x-www-form-urlencoded")
+                      .POST(
+                          HttpRequest.BodyPublishers.ofString(
+                              "token="
+                                  + URLEncoder.encode(token.accessToken(), StandardCharsets.UTF_8)))
+                      .build(),
+                  HttpResponse.BodyHandlers.ofString());
+      assertThat(introspection.statusCode()).isEqualTo(200);
+      assertThat(introspection.body()).contains("\"active\":true");
+      assertThat(introspection.body()).contains("\"sub\":\"user-123\"");
+    }
+  }
+
+  @Test
+  public void authorizationCodeFlowWithPkceSucceeds() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      FlowResult result =
+          container.authorizationCodeFlow().scopes("openid").usePkce(true).execute();
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      assertThat(((FlowResult.TokenResponse) result).accessToken()).isNotBlank();
+    }
+  }
+
+  @Test
+  public void authorizationCodeFlowWithPreRegisteredClientSucceeds() throws Exception {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+      createClient(container, "known-app", "known-secret", "openid");
+
+      FlowResult result =
+          container
+              .authorizationCodeFlow()
+              .clientId("known-app")
+              .clientSecret("known-secret")
+              .scopes("openid")
+              .execute();
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      assertThat(((FlowResult.TokenResponse) result).accessToken()).isNotBlank();
+    }
+  }
+
+  @Test
+  public void requestingScopeNotRegisteredOnClientReturnsOAuthError() throws Exception {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+      createClient(container, "narrow-app", "narrow-secret", "openid");
+
+      FlowResult result =
+          container
+              .authorizationCodeFlow()
+              .clientId("narrow-app")
+              .clientSecret("narrow-secret")
+              .scopes("openid", "email")
+              .execute();
+
+      assertThat(result).isInstanceOf(FlowResult.OAuthError.class);
+      assertThat(((FlowResult.OAuthError) result).error()).isEqualTo("invalid_scope");
+    }
+  }
+
+  @Test
+  public void rejectedLoginReturnsOAuthError() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      FlowResult result =
+          container
+              .authorizationCodeFlow()
+              .scopes("openid")
+              .rejectLogin("login_required", "user could not be authenticated")
+              .execute();
+
+      assertThat(result).isInstanceOf(FlowResult.OAuthError.class);
+      assertThat(((FlowResult.OAuthError) result).error()).isEqualTo("login_required");
+    }
+  }
+
+  @Test
+  public void rejectedConsentReturnsOAuthError() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      FlowResult result =
+          container
+              .authorizationCodeFlow()
+              .scopes("openid")
+              .rejectConsent("access_denied", "user declined")
+              .execute();
+
+      assertThat(result).isInstanceOf(FlowResult.OAuthError.class);
+      assertThat(((FlowResult.OAuthError) result).error()).isEqualTo("access_denied");
+    }
+  }
+
+  private static void createClient(
+      OryHydraContainer container, String clientId, String clientSecret, String scope)
+      throws Exception {
+    var create =
+        container.execInContainer(
+            "hydra",
+            "create",
+            "oauth2-client",
+            "--endpoint",
+            "http://127.0.0.1:4445",
+            "--grant-type",
+            "authorization_code",
+            "--response-type",
+            "code",
+            "--token-endpoint-auth-method",
+            "client_secret_basic",
+            "--scope",
+            scope,
+            "--redirect-uri",
+            "http://localhost/callback",
+            "--id",
+            clientId,
+            "--secret",
+            clientSecret);
+    assertThat(create.getExitCode()).isZero();
+  }
+}


### PR DESCRIPTION
Adds a fluent authorization-code flow driver that returns a real token without a browser or a user-written login/consent app: it follows Hydra's redirects manually, answers the login and consent challenges via the admin API (configurable subject, scopes, audience, and session claims), and supports PKCE (S256) plus real denial paths via rejectLogin/rejectConsent. URLS_LOGIN/URLS_CONSENT now default to non-resolvable sentinel hosts, which the driver never contacts because challenges are intercepted by query parameter; explicit overrides and externally driven flows are unaffected (guarded by the regression test from #194). README documentation now leads with the authorization-code flow.