### PR TITLE
feat: add redirectUri() and harden the authorization-code flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ var error = (FlowResult.OAuthError) hydra.authorizationCodeFlow()
 ```
 
 To exercise a specific pre-registered client instead of an ephemeral one, pass
-`clientId(...)`/`clientSecret(...)`. The flow currently uses the fixed redirect URI
-`http://localhost/callback` (never actually served), so a pre-registered client must include that
-value in its `redirect_uris`.
+`clientId(...)`/`clientSecret(...)`. The flow's redirect URI defaults to
+`http://localhost/callback` and can be overridden with `redirectUri(...)` to match the client's
+registered `redirect_uris` — it is never actually served either way.
 
 #### Client credentials
 

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
@@ -3,7 +3,6 @@ package com.ardetrick.testcontainers.oauth2;
 import com.ardetrick.testcontainers.oauth2.FlowResult.OAuthError;
 import java.net.CookieManager;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -17,6 +16,7 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -32,7 +32,7 @@ import java.util.UUID;
  */
 public final class AuthorizationCodeFlow {
 
-  private static final String REDIRECT_URI = "http://localhost/callback";
+  private static final String DEFAULT_REDIRECT_URI = "http://localhost/callback";
   private static final int MAX_HOPS = 10;
 
   private final URI publicBaseUri;
@@ -50,6 +50,7 @@ public final class AuthorizationCodeFlow {
   private String rejectConsentError;
   private String rejectConsentDescription;
   private boolean usePkce = false;
+  private String redirectUri = DEFAULT_REDIRECT_URI;
 
   /**
    * Creates a flow bound to a running Hydra container's endpoints.
@@ -66,8 +67,8 @@ public final class AuthorizationCodeFlow {
    * Uses an existing client instead of creating an ephemeral one. Requires {@link
    * #clientSecret(String)}.
    *
-   * <p>The flow uses the fixed redirect URI {@code http://localhost/callback} (never actually
-   * served), so the client must include it in its registered {@code redirect_uris}.
+   * <p>The client must include the flow's redirect URI — default {@code http://localhost/callback},
+   * configurable via {@link #redirectUri(String)} — in its registered {@code redirect_uris}.
    *
    * @param clientId the client identifier
    * @return this flow
@@ -85,6 +86,20 @@ public final class AuthorizationCodeFlow {
    */
   public AuthorizationCodeFlow clientSecret(String clientSecret) {
     this.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * Sets the redirect URI used in the authorization request and token exchange (default {@code
+   * http://localhost/callback}). It is never actually served — the flow intercepts the redirect
+   * before any request is made to it — but a client supplied via {@link #clientId(String)} must
+   * include it in its registered {@code redirect_uris}.
+   *
+   * @param redirectUri the redirect URI to use
+   * @return this flow
+   */
+  public AuthorizationCodeFlow redirectUri(String redirectUri) {
+    this.redirectUri = redirectUri;
     return this;
   }
 
@@ -282,7 +297,7 @@ public final class AuthorizationCodeFlow {
         clientId,
         clientSecret,
         code,
-        REDIRECT_URI,
+        redirectUri,
         codeVerifier);
   }
 
@@ -300,7 +315,7 @@ public final class AuthorizationCodeFlow {
     registration.put("client_secret", secret);
     registration.put("grant_types", List.of("authorization_code", "refresh_token"));
     registration.put("response_types", List.of("code"));
-    registration.put("redirect_uris", List.of(REDIRECT_URI));
+    registration.put("redirect_uris", List.of(redirectUri));
     registration.put("scope", String.join(" ", scopes));
     registration.put("token_endpoint_auth_method", "client_secret_basic");
     if (!audience.isEmpty()) {
@@ -326,7 +341,7 @@ public final class AuthorizationCodeFlow {
     StringBuilder query = new StringBuilder();
     query.append("client_id=").append(Http.encode(clientId));
     query.append("&response_type=code");
-    query.append("&redirect_uri=").append(Http.encode(REDIRECT_URI));
+    query.append("&redirect_uri=").append(Http.encode(redirectUri));
     query.append("&scope=").append(Http.encode(String.join(" ", scopes)));
     query.append("&state=").append(Http.encode(state));
     for (String aud : audience) {
@@ -340,24 +355,25 @@ public final class AuthorizationCodeFlow {
   }
 
   private boolean isRedirectUri(URI location) {
-    URI redirect = URI.create(REDIRECT_URI);
-    return redirect.getHost().equals(location.getHost())
-        && redirect.getPath().equals(location.getPath());
+    URI redirect = URI.create(redirectUri);
+    return Objects.equals(redirect.getScheme(), location.getScheme())
+        && Objects.equals(redirect.getHost(), location.getHost())
+        && redirect.getPort() == location.getPort()
+        && Objects.equals(redirect.getPath(), location.getPath());
   }
 
+  // Swaps in the mapped authority while keeping the raw path/query untouched: decoding and
+  // re-encoding could corrupt values that legitimately contain encoded separators.
   private URI rewrite(URI location) {
-    try {
-      return new URI(
-          publicBaseUri.getScheme(),
-          null,
-          publicBaseUri.getHost(),
-          publicBaseUri.getPort(),
-          location.getPath(),
-          location.getQuery(),
-          location.getFragment());
-    } catch (URISyntaxException e) {
-      throw new HydraFlowException("Failed to rewrite redirect URI: " + location, e);
-    }
+    String query = location.getRawQuery() == null ? "" : "?" + location.getRawQuery();
+    String fragment = location.getRawFragment() == null ? "" : "#" + location.getRawFragment();
+    return URI.create(
+        publicBaseUri.getScheme()
+            + "://"
+            + publicBaseUri.getAuthority()
+            + location.getRawPath()
+            + query
+            + fragment);
   }
 
   private static Map<String, String> parseQuery(String rawQuery) {

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/Json.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/Json.java
@@ -94,9 +94,17 @@ final class Json {
           case 'r' -> sb.append('\r');
           case 't' -> sb.append('\t');
           case 'u' -> {
+            if (pos + 4 > src.length()) {
+              throw new JsonParseException("Truncated unicode escape at index " + pos);
+            }
             String hex = src.substring(pos, pos + 4);
             pos += 4;
-            sb.append((char) Integer.parseInt(hex, 16));
+            try {
+              sb.append((char) Integer.parseInt(hex, 16));
+            } catch (NumberFormatException e) {
+              throw new JsonParseException(
+                  "Invalid unicode escape '\\u" + hex + "' at index " + (pos - 4));
+            }
           }
           default -> throw new JsonParseException("Invalid escape '\\" + esc + "' at index " + pos);
         }

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
@@ -46,9 +46,13 @@ final class TokenEndpointClient {
 
   private static FlowResult post(
       URI tokenEndpoint, String form, String clientId, String clientSecret) {
+    // RFC 6749 §2.3.1: client id and secret are form-urlencoded before being concatenated
+    // and Base64-encoded, so secrets containing ':' or '%' authenticate correctly.
     String credentials =
         Base64.getEncoder()
-            .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+            .encodeToString(
+                (Http.encode(clientId) + ":" + Http.encode(clientSecret))
+                    .getBytes(StandardCharsets.UTF_8));
     HttpResponse<String> response =
         Http.send(
             HttpClient.newHttpClient(),

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
@@ -77,6 +77,27 @@ public class OryHydraContainerAuthorizationCodeFlowTest {
   }
 
   @Test
+  public void authorizationCodeFlowWithCustomRedirectUriSucceeds() throws Exception {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+      var customRedirectUri = "http://my-app.example:8443/oauth/callback";
+      createClient(container, "custom-redirect-app", "custom-secret", "openid", customRedirectUri);
+
+      FlowResult result =
+          container
+              .authorizationCodeFlow()
+              .clientId("custom-redirect-app")
+              .clientSecret("custom-secret")
+              .scopes("openid")
+              .redirectUri(customRedirectUri)
+              .execute();
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      assertThat(((FlowResult.TokenResponse) result).accessToken()).isNotBlank();
+    }
+  }
+
+  @Test
   public void authorizationCodeFlowWithPreRegisteredClientSucceeds() throws Exception {
     try (var container = OryHydraContainer.builder().build()) {
       container.start();
@@ -151,6 +172,16 @@ public class OryHydraContainerAuthorizationCodeFlowTest {
   private static void createClient(
       OryHydraContainer container, String clientId, String clientSecret, String scope)
       throws Exception {
+    createClient(container, clientId, clientSecret, scope, "http://localhost/callback");
+  }
+
+  private static void createClient(
+      OryHydraContainer container,
+      String clientId,
+      String clientSecret,
+      String scope,
+      String redirectUri)
+      throws Exception {
     var create =
         container.execInContainer(
             "hydra",
@@ -167,7 +198,7 @@ public class OryHydraContainerAuthorizationCodeFlowTest {
             "--scope",
             scope,
             "--redirect-uri",
-            "http://localhost/callback",
+            redirectUri,
             "--id",
             clientId,
             "--secret",

--- a/src/test/java/com/ardetrick/testcontainers/oauth2/JsonTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/oauth2/JsonTest.java
@@ -49,4 +49,16 @@ class JsonTest {
   void rejectsTrailingContent() {
     assertThatThrownBy(() -> Json.parseObject("{} extra")).isInstanceOf(JsonParseException.class);
   }
+
+  @Test
+  void rejectsTruncatedUnicodeEscape() {
+    assertThatThrownBy(() -> Json.parseObject("{\"k\":\"\\u00"))
+        .isInstanceOf(JsonParseException.class);
+  }
+
+  @Test
+  void rejectsInvalidUnicodeEscape() {
+    assertThatThrownBy(() -> Json.parseObject("{\"k\":\"\\uZZZZ\"}"))
+        .isInstanceOf(JsonParseException.class);
+  }
 }

--- a/src/test/java/com/ardetrick/testcontainers/oauth2/OryHydraContainerPkceEnforcementTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/oauth2/OryHydraContainerPkceEnforcementTest.java
@@ -1,0 +1,129 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ardetrick.testcontainers.OryHydraContainer;
+import java.net.CookieManager;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves Hydra actually enforces the PKCE S256 challenge the flow driver sends — a happy-path PKCE
+ * test alone cannot distinguish enforcement from the challenge being silently ignored.
+ *
+ * <p>Drives the flow manually (the driver's verifier is internal, so a wrong verifier cannot be
+ * injected through the public API) and exchanges the code with a verifier that does not match the
+ * challenge, expecting rejection. Pinning this behavior guards it across Hydra image upgrades.
+ */
+public class OryHydraContainerPkceEnforcementTest {
+
+  static final String REDIRECT_URI = "http://localhost/callback";
+
+  @Test
+  public void wrongPkceVerifierIsRejected() throws Exception {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+      var publicBase = URI.create(container.publicBaseUriString());
+      var http =
+          HttpClient.newBuilder()
+              .cookieHandler(new CookieManager())
+              .followRedirects(HttpClient.Redirect.NEVER)
+              .build();
+      var admin = new AdminClient(http, URI.create(container.adminBaseUriString()));
+
+      Map<String, Object> registration = new LinkedHashMap<>();
+      registration.put("client_id", "pkce-client");
+      registration.put("client_secret", "pkce-secret");
+      registration.put("grant_types", List.of("authorization_code"));
+      registration.put("response_types", List.of("code"));
+      registration.put("redirect_uris", List.of(REDIRECT_URI));
+      registration.put("scope", "openid");
+      registration.put("token_endpoint_auth_method", "client_secret_basic");
+      admin.createClient(registration);
+
+      var verifier = "correct-verifier-correct-verifier-correct-verifier-1234";
+      var challenge =
+          Base64.getUrlEncoder()
+              .withoutPadding()
+              .encodeToString(
+                  MessageDigest.getInstance("SHA-256")
+                      .digest(verifier.getBytes(StandardCharsets.US_ASCII)));
+
+      var current =
+          publicBase.resolve(
+              "/oauth2/auth?client_id=pkce-client&response_type=code&scope=openid"
+                  + "&state=pkce-enforcement-state"
+                  + "&redirect_uri="
+                  + Http.encode(REDIRECT_URI)
+                  + "&code_challenge="
+                  + challenge
+                  + "&code_challenge_method=S256");
+
+      String code = null;
+      for (int hop = 0; hop < 10 && code == null; hop++) {
+        var response =
+            http.send(
+                HttpRequest.newBuilder(current).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(Http.is3xx(response.statusCode()))
+            .as("expected redirect, got: %s", response.body())
+            .isTrue();
+        var location = current.resolve(response.headers().firstValue("location").orElseThrow());
+        var query = location.getRawQuery() == null ? "" : location.getRawQuery();
+        if (query.contains("login_challenge=")) {
+          current =
+              onPublicPort(admin.acceptLogin(param(query, "login_challenge"), "u"), publicBase);
+        } else if (query.contains("consent_challenge=")) {
+          current =
+              onPublicPort(
+                  admin.acceptConsent(
+                      param(query, "consent_challenge"), List.of("openid"), List.of(), Map.of()),
+                  publicBase);
+        } else if ("localhost".equals(location.getHost())
+            && "/callback".equals(location.getPath())) {
+          code = param(query, "code");
+        } else {
+          current = onPublicPort(location, publicBase);
+        }
+      }
+      assertThat(code).isNotNull();
+
+      // Exchange the code with a verifier that does NOT match the challenge above.
+      var result =
+          TokenEndpointClient.authorizationCode(
+              publicBase.resolve("/oauth2/token"),
+              "pkce-client",
+              "pkce-secret",
+              code,
+              REDIRECT_URI,
+              "wrong-verifier-wrong-verifier-wrong-verifier-9999999999");
+
+      assertThat(result)
+          .as("Hydra must reject a code exchange whose verifier does not match the challenge")
+          .isInstanceOf(FlowResult.OAuthError.class);
+    }
+  }
+
+  private static String param(String rawQuery, String name) {
+    for (String pair : rawQuery.split("&")) {
+      if (pair.startsWith(name + "=")) {
+        return Http.decode(pair.substring(name.length() + 1));
+      }
+    }
+    return null;
+  }
+
+  private static URI onPublicPort(URI location, URI publicBase) {
+    var query = location.getRawQuery() == null ? "" : "?" + location.getRawQuery();
+    return URI.create(publicBase + location.getRawPath() + query);
+  }
+}


### PR DESCRIPTION
Adds a redirectUri(String) option so pre-registered clients with real redirect URIs can complete the flow (the URI is still never served). Hardens the driver: redirect matching now compares scheme/host/port/path against the configured URI; authority rewriting preserves the raw query instead of decoding and re-encoding it; client_secret_basic credentials are form-urlencoded per RFC 6749 §2.3.1; the JSON reader reports truncated or invalid unicode escapes as JsonParseException. Adds a PKCE-enforcement test proving Hydra rejects a mismatched verifier, pinning that behavior across image upgrades.