### PR TITLE
feat: restore 0.0.5 URI helpers as deprecated

### DIFF
--- a/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
+++ b/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
@@ -205,6 +205,128 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
     return URI.create(publicBaseUriString() + "/oauth2/token");
   }
 
+  // The helpers below were released in 0.0.5 and are retained for backwards compatibility only.
+  // Their endpoint URIs are all discoverable via the document at getOpenIdDiscoveryUri().
+
+  /**
+   * Builds a convenience link to the OAuth2 authorization endpoint.
+   *
+   * @return absolute URI pointing to {@code /oauth2/auth} on the public endpoint.
+   * @deprecated resolve {@code authorization_endpoint} from {@link #getOpenIdDiscoveryUri()}
+   *     instead; scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getOAuth2AuthUri() {
+    return URI.create(publicBaseUriString() + "/oauth2/auth");
+  }
+
+  /**
+   * Builds a convenience link to the JSON Web Key Set endpoint.
+   *
+   * @return absolute URI pointing to {@code /.well-known/jwks.json} on the public endpoint.
+   * @deprecated resolve {@code jwks_uri} from {@link #getOpenIdDiscoveryUri()} instead; scheduled
+   *     for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getPublicJwksUri() {
+    return URI.create(publicBaseUriString() + "/.well-known/jwks.json");
+  }
+
+  /**
+   * Builds a convenience link to the OAuth 2.0 authorization server metadata endpoint.
+   *
+   * @return absolute URI pointing to {@code /.well-known/oauth-authorization-server} on the public
+   *     endpoint.
+   * @deprecated use {@link #getOpenIdDiscoveryUri()} or build the path from {@link
+   *     #publicBaseUriString()}; scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getOAuthAuthorizationServerDiscoveryUri() {
+    return URI.create(publicBaseUriString() + "/.well-known/oauth-authorization-server");
+  }
+
+  /**
+   * Builds a convenience link to the OAuth2 token revocation endpoint.
+   *
+   * @return absolute URI pointing to {@code /oauth2/revoke} on the public endpoint.
+   * @deprecated resolve {@code revocation_endpoint} from {@link #getOpenIdDiscoveryUri()} instead;
+   *     scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getOAuth2RevokeUri() {
+    return URI.create(publicBaseUriString() + "/oauth2/revoke");
+  }
+
+  /**
+   * Builds a convenience link to the OpenID Connect userinfo endpoint.
+   *
+   * @return absolute URI pointing to {@code /userinfo} on the public endpoint.
+   * @deprecated resolve {@code userinfo_endpoint} from {@link #getOpenIdDiscoveryUri()} instead;
+   *     scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getUserInfoUri() {
+    return URI.create(publicBaseUriString() + "/userinfo");
+  }
+
+  /**
+   * Builds a convenience link to the OpenID Connect logout endpoint.
+   *
+   * @return absolute URI pointing to {@code /oauth2/sessions/logout} on the public endpoint.
+   * @deprecated resolve {@code end_session_endpoint} from {@link #getOpenIdDiscoveryUri()} instead;
+   *     scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getOAuth2SessionsLogoutUri() {
+    return URI.create(publicBaseUriString() + "/oauth2/sessions/logout");
+  }
+
+  /**
+   * Builds a convenience link to the admin clients endpoint.
+   *
+   * @return absolute URI pointing to {@code /admin/clients} on the admin endpoint.
+   * @deprecated build the path from {@link #adminBaseUriString()}; scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getAdminClientsUri() {
+    return URI.create(adminBaseUriString() + "/admin/clients");
+  }
+
+  /**
+   * Builds a convenience link to the admin token introspection endpoint.
+   *
+   * @return absolute URI pointing to {@code /admin/oauth2/introspect} on the admin endpoint.
+   * @deprecated build the path from {@link #adminBaseUriString()}; scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getAdminOAuth2IntrospectUri() {
+    return URI.create(adminBaseUriString() + "/admin/oauth2/introspect");
+  }
+
+  /**
+   * Builds a convenience link to the admin login request endpoint.
+   *
+   * @return absolute URI pointing to {@code /admin/oauth2/auth/requests/login} on the admin
+   *     endpoint.
+   * @deprecated build the path from {@link #adminBaseUriString()}; scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getAdminLoginRequestUri() {
+    return URI.create(adminBaseUriString() + "/admin/oauth2/auth/requests/login");
+  }
+
+  /**
+   * Builds a convenience link to the admin consent request endpoint.
+   *
+   * @return absolute URI pointing to {@code /admin/oauth2/auth/requests/consent} on the admin
+   *     endpoint.
+   * @deprecated build the path from {@link #adminBaseUriString()}; scheduled for removal.
+   */
+  @Deprecated(since = "0.0.6", forRemoval = true)
+  public URI getAdminConsentRequestUri() {
+    return URI.create(adminBaseUriString() + "/admin/oauth2/auth/requests/consent");
+  }
+
   /** Fluent builder for configuring the Hydra container. */
   public static class Builder {
 

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerDeprecatedUriHelpersTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerDeprecatedUriHelpersTest.java
@@ -1,0 +1,38 @@
+package com.ardetrick.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the URI helpers released in 0.0.5 and deprecated since 0.0.6. Delete this class together
+ * with the helpers when the deprecation cycle completes.
+ */
+@SuppressWarnings("removal")
+public class OryHydraContainerDeprecatedUriHelpersTest {
+
+  @Test
+  public void deprecatedUriHelpersStillResolveTheir005Paths() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+      var publicBase = container.publicBaseUriString();
+      var adminBase = container.adminBaseUriString();
+
+      assertThat(container.getOAuth2AuthUri()).hasToString(publicBase + "/oauth2/auth");
+      assertThat(container.getPublicJwksUri()).hasToString(publicBase + "/.well-known/jwks.json");
+      assertThat(container.getOAuthAuthorizationServerDiscoveryUri())
+          .hasToString(publicBase + "/.well-known/oauth-authorization-server");
+      assertThat(container.getOAuth2RevokeUri()).hasToString(publicBase + "/oauth2/revoke");
+      assertThat(container.getUserInfoUri()).hasToString(publicBase + "/userinfo");
+      assertThat(container.getOAuth2SessionsLogoutUri())
+          .hasToString(publicBase + "/oauth2/sessions/logout");
+      assertThat(container.getAdminClientsUri()).hasToString(adminBase + "/admin/clients");
+      assertThat(container.getAdminOAuth2IntrospectUri())
+          .hasToString(adminBase + "/admin/oauth2/introspect");
+      assertThat(container.getAdminLoginRequestUri())
+          .hasToString(adminBase + "/admin/oauth2/auth/requests/login");
+      assertThat(container.getAdminConsentRequestUri())
+          .hasToString(adminBase + "/admin/oauth2/auth/requests/consent");
+    }
+  }
+}


### PR DESCRIPTION
Re-adds the ten endpoint URI helpers that #163 removed after the 0.0.5 release, marked @Deprecated(since = "0.0.6", forRemoval = true) with javadoc pointing at the OpenID discovery document (or the base URI strings) as the replacement. This turns an unreleased breaking change into a deprecation cycle: 0.0.5 users upgrade without compile errors and get removal warnings at each call site instead. A dedicated test pins all ten paths and is deleted with the helpers when the cycle completes.