### PR TITLE
feat: add token introspection and OpenID discovery helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,35 @@ var token = (FlowResult.TokenResponse) result;
 String accessToken = token.accessToken();
 ```
 
+#### Validating tokens with introspection
+
+Hydra issues opaque access tokens by default, so resource servers validate them via
+introspection (RFC 7662) — and your test can do the same to assert a minted token is real,
+active, and carries what you configured:
+
+```java
+var introspection = hydra.introspect(token.accessToken());
+introspection.active();          // true
+introspection.subject();         // "user-123"
+introspection.raw().get("ext");  // custom session claims, e.g. {email=user-123@example.com}
+```
+
+Unknown or expired tokens return `active() == false` rather than throwing.
+
+#### Resolving endpoints from the discovery document
+
+`openIdConfiguration()` fetches and parses `/.well-known/openid-configuration`. Because Hydra
+advertises endpoints using its configured issuer — which cannot know the container's dynamically
+mapped port — the typed accessors are re-targeted at the mapped public port and are directly
+usable; the as-advertised values remain available via `raw()`:
+
+```java
+URI jwksUri = hydra.openIdConfiguration().jwksUri();
+URI tokenEndpoint = hydra.openIdConfiguration().tokenEndpoint();
+```
+
+These accessors are the migration target for the URI helpers deprecated since 0.0.6.
+
 #### Testing a real login/consent app
 
 The flow driver above replaces the login/consent app so you don't have to write one. If the thing

--- a/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
+++ b/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
@@ -2,6 +2,8 @@ package com.ardetrick.testcontainers;
 
 import com.ardetrick.testcontainers.oauth2.AuthorizationCodeFlow;
 import com.ardetrick.testcontainers.oauth2.ClientCredentialsFlow;
+import com.ardetrick.testcontainers.oauth2.IntrospectionResponse;
+import com.ardetrick.testcontainers.oauth2.OpenIdConfiguration;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
@@ -187,6 +189,33 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
   }
 
   /**
+   * Fetches and parses the OpenID Connect discovery document from this container.
+   *
+   * <p>Endpoint accessors are re-targeted at the mapped public host and port (the document
+   * advertises Hydra's configured issuer, which cannot know the mapped port), so values like {@link
+   * OpenIdConfiguration#jwksUri()} are directly usable from the test.
+   *
+   * @return the parsed discovery document
+   */
+  public OpenIdConfiguration openIdConfiguration() {
+    return OpenIdConfiguration.fetch(URI.create(publicBaseUriString()));
+  }
+
+  /**
+   * Introspects a token via Hydra's admin API (RFC 7662).
+   *
+   * <p>Hydra issues opaque access tokens by default, so this is how a test asserts a minted token
+   * is real, active, and attributed to the expected subject — the same check a resource server
+   * under test performs.
+   *
+   * @param token the access or refresh token to introspect
+   * @return the introspection response; inactive or unknown tokens return {@code active == false}
+   */
+  public IntrospectionResponse introspect(String token) {
+    return IntrospectionResponse.request(URI.create(adminBaseUriString()), token);
+  }
+
+  /**
    * Builds a convenience link to the OpenID Connect discovery endpoint.
    *
    * @return absolute URI pointing to {@code /.well-known/openid-configuration} on the public
@@ -212,8 +241,8 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    * Builds a convenience link to the OAuth2 authorization endpoint.
    *
    * @return absolute URI pointing to {@code /oauth2/auth} on the public endpoint.
-   * @deprecated resolve {@code authorization_endpoint} from {@link #getOpenIdDiscoveryUri()}
-   *     instead; scheduled for removal.
+   * @deprecated use {@code openIdConfiguration().authorizationEndpoint()} instead; scheduled for
+   *     removal.
    */
   @Deprecated(since = "0.0.6", forRemoval = true)
   public URI getOAuth2AuthUri() {
@@ -224,8 +253,7 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    * Builds a convenience link to the JSON Web Key Set endpoint.
    *
    * @return absolute URI pointing to {@code /.well-known/jwks.json} on the public endpoint.
-   * @deprecated resolve {@code jwks_uri} from {@link #getOpenIdDiscoveryUri()} instead; scheduled
-   *     for removal.
+   * @deprecated use {@code openIdConfiguration().jwksUri()} instead; scheduled for removal.
    */
   @Deprecated(since = "0.0.6", forRemoval = true)
   public URI getPublicJwksUri() {
@@ -237,7 +265,7 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    *
    * @return absolute URI pointing to {@code /.well-known/oauth-authorization-server} on the public
    *     endpoint.
-   * @deprecated use {@link #getOpenIdDiscoveryUri()} or build the path from {@link
+   * @deprecated use {@link #openIdConfiguration()} or build the path from {@link
    *     #publicBaseUriString()}; scheduled for removal.
    */
   @Deprecated(since = "0.0.6", forRemoval = true)
@@ -249,8 +277,8 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    * Builds a convenience link to the OAuth2 token revocation endpoint.
    *
    * @return absolute URI pointing to {@code /oauth2/revoke} on the public endpoint.
-   * @deprecated resolve {@code revocation_endpoint} from {@link #getOpenIdDiscoveryUri()} instead;
-   *     scheduled for removal.
+   * @deprecated use {@code openIdConfiguration().revocationEndpoint()} instead; scheduled for
+   *     removal.
    */
   @Deprecated(since = "0.0.6", forRemoval = true)
   public URI getOAuth2RevokeUri() {
@@ -261,8 +289,8 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    * Builds a convenience link to the OpenID Connect userinfo endpoint.
    *
    * @return absolute URI pointing to {@code /userinfo} on the public endpoint.
-   * @deprecated resolve {@code userinfo_endpoint} from {@link #getOpenIdDiscoveryUri()} instead;
-   *     scheduled for removal.
+   * @deprecated use {@code openIdConfiguration().userinfoEndpoint()} instead; scheduled for
+   *     removal.
    */
   @Deprecated(since = "0.0.6", forRemoval = true)
   public URI getUserInfoUri() {
@@ -273,8 +301,8 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    * Builds a convenience link to the OpenID Connect logout endpoint.
    *
    * @return absolute URI pointing to {@code /oauth2/sessions/logout} on the public endpoint.
-   * @deprecated resolve {@code end_session_endpoint} from {@link #getOpenIdDiscoveryUri()} instead;
-   *     scheduled for removal.
+   * @deprecated use {@code openIdConfiguration().endSessionEndpoint()} instead; scheduled for
+   *     removal.
    */
   @Deprecated(since = "0.0.6", forRemoval = true)
   public URI getOAuth2SessionsLogoutUri() {
@@ -296,7 +324,8 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    * Builds a convenience link to the admin token introspection endpoint.
    *
    * @return absolute URI pointing to {@code /admin/oauth2/introspect} on the admin endpoint.
-   * @deprecated build the path from {@link #adminBaseUriString()}; scheduled for removal.
+   * @deprecated use {@link #introspect(String)} instead, or build the path from {@link
+   *     #adminBaseUriString()}; scheduled for removal.
    */
   @Deprecated(since = "0.0.6", forRemoval = true)
   public URI getAdminOAuth2IntrospectUri() {

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/IntrospectionResponse.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/IntrospectionResponse.java
@@ -1,0 +1,68 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Result of introspecting a token via Hydra's admin API (RFC 7662).
+ *
+ * <p>Hydra issues opaque access tokens by default, so introspection is the way a resource server
+ * validates them — introspecting a minted token is how a test asserts the token is real, active,
+ * and attributed to the expected subject.
+ *
+ * @param active whether the token is currently active (RFC 7662 §2.2); {@code false} for unknown,
+ *     expired, or revoked tokens
+ * @param subject the token's subject ({@code sub}), or {@code null} when absent (e.g. inactive
+ *     tokens, or client-credentials tokens attribute the client instead)
+ * @param scope the granted scope (space-delimited), or {@code null} when absent
+ * @param clientId the client the token was issued to, or {@code null} when absent
+ * @param raw the full parsed introspection response; custom session claims appear under {@code ext}
+ */
+public record IntrospectionResponse(
+    boolean active, String subject, String scope, String clientId, Map<String, Object> raw) {
+
+  /**
+   * Introspects a token via {@code POST /admin/oauth2/introspect}.
+   *
+   * @param adminBaseUri the admin API base URI
+   * @param token the access or refresh token to introspect
+   * @return the parsed introspection response; inactive tokens return {@code active == false}
+   *     rather than throwing
+   * @throws HydraFlowException if the request cannot be completed or the response cannot be parsed
+   */
+  public static IntrospectionResponse request(URI adminBaseUri, String token) {
+    HttpResponse<String> response =
+        Http.send(
+            HttpClient.newHttpClient(),
+            HttpRequest.newBuilder(adminBaseUri.resolve("/admin/oauth2/introspect"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("token=" + Http.encode(token)))
+                .build());
+    if (!Http.is2xx(response.statusCode())) {
+      throw new HydraFlowException(
+          "Introspection failed (HTTP " + response.statusCode() + "): " + response.body());
+    }
+    Map<String, Object> json;
+    try {
+      json = Json.parseObject(response.body());
+    } catch (JsonParseException e) {
+      throw new HydraFlowException("Unparseable introspection response: " + response.body(), e);
+    }
+    return new IntrospectionResponse(
+        Boolean.TRUE.equals(json.get("active")),
+        string(json, "sub"),
+        string(json, "scope"),
+        string(json, "client_id"),
+        Collections.unmodifiableMap(json));
+  }
+
+  private static String string(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    return value == null ? null : value.toString();
+  }
+}

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/Json.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/Json.java
@@ -1,13 +1,16 @@
 package com.ardetrick.testcontainers.oauth2;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Minimal JSON reader for flat objects (no nested objects or arrays).
+ * Minimal JSON reader.
  *
- * <p>Sufficient for OAuth 2.0 token and error responses, whose members are all primitives. Kept
- * dependency-free on purpose; richer parsing can be added if a future feature needs nested values.
+ * <p>Covers the documents this library consumes: OAuth 2.0 token and error responses, RFC 7662
+ * introspection responses ({@code ext}, {@code aud}), and the OpenID Connect discovery document.
+ * Kept dependency-free on purpose.
  */
 final class Json {
 
@@ -19,12 +22,12 @@ final class Json {
   }
 
   /**
-   * Parses a flat JSON object into an insertion-ordered map.
+   * Parses a JSON object into an insertion-ordered map.
    *
    * @param json the JSON text
    * @return the parsed members (values are {@link String}, {@link Long}, {@link Double}, {@link
-   *     Boolean}, or {@code null})
-   * @throws JsonParseException if the text is not a flat JSON object
+   *     Boolean}, {@code null}, {@link List}, or nested {@link Map})
+   * @throws JsonParseException if the text is not a JSON object
    */
   static Map<String, Object> parseObject(String json) {
     Json parser = new Json(json);
@@ -69,9 +72,32 @@ final class Json {
       case '"' -> readString();
       case 't', 'f' -> readBoolean();
       case 'n' -> readNull();
-      case '{', '[' -> throw new JsonParseException("Nested JSON is not supported at index " + pos);
+      case '{' -> object();
+      case '[' -> array();
       default -> readNumber();
     };
+  }
+
+  private List<Object> array() {
+    expect('[');
+    List<Object> list = new ArrayList<>();
+    skipWhitespace();
+    if (peek() == ']') {
+      pos++;
+      return list;
+    }
+    while (true) {
+      skipWhitespace();
+      list.add(readValue());
+      skipWhitespace();
+      char c = nextChar();
+      if (c == ']') {
+        return list;
+      }
+      if (c != ',') {
+        throw new JsonParseException("Expected ',' or ']' at index " + (pos - 1));
+      }
+    }
   }
 
   private String readString() {

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/OpenIdConfiguration.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/OpenIdConfiguration.java
@@ -1,0 +1,98 @@
+package com.ardetrick.testcontainers.oauth2;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * The OpenID Connect discovery document, fetched from {@code /.well-known/openid-configuration} and
+ * parsed into typed endpoint accessors.
+ *
+ * <p>The document advertises endpoints using Hydra's configured issuer, which cannot know the
+ * container's dynamically mapped port — so each endpoint accessor is re-targeted at the mapped
+ * public host and port and is directly usable from the test. The as-advertised values are preserved
+ * in {@link #raw()}.
+ *
+ * @param issuer the advertised issuer identifier, as-is (not re-targeted)
+ * @param authorizationEndpoint the OAuth 2.0 authorization endpoint, or {@code null} if absent
+ * @param tokenEndpoint the OAuth 2.0 token endpoint, or {@code null} if absent
+ * @param jwksUri the JSON Web Key Set endpoint, or {@code null} if absent
+ * @param userinfoEndpoint the OIDC userinfo endpoint, or {@code null} if absent
+ * @param revocationEndpoint the token revocation endpoint, or {@code null} if absent
+ * @param endSessionEndpoint the OIDC logout endpoint, or {@code null} if absent
+ * @param raw the full parsed document with as-advertised values
+ */
+public record OpenIdConfiguration(
+    String issuer,
+    URI authorizationEndpoint,
+    URI tokenEndpoint,
+    URI jwksUri,
+    URI userinfoEndpoint,
+    URI revocationEndpoint,
+    URI endSessionEndpoint,
+    Map<String, Object> raw) {
+
+  /**
+   * Fetches and parses the discovery document from the given public API base URI.
+   *
+   * @param publicBaseUri the public API base URI (host and mapped port)
+   * @return the parsed document with endpoint accessors re-targeted at {@code publicBaseUri}
+   * @throws HydraFlowException if the request cannot be completed or the response cannot be parsed
+   */
+  public static OpenIdConfiguration fetch(URI publicBaseUri) {
+    HttpResponse<String> response =
+        Http.send(
+            HttpClient.newHttpClient(),
+            HttpRequest.newBuilder(publicBaseUri.resolve("/.well-known/openid-configuration"))
+                .header("Accept", "application/json")
+                .GET()
+                .build());
+    if (!Http.is2xx(response.statusCode())) {
+      throw new HydraFlowException(
+          "Fetching the discovery document failed (HTTP "
+              + response.statusCode()
+              + "): "
+              + response.body());
+    }
+    Map<String, Object> json;
+    try {
+      json = Json.parseObject(response.body());
+    } catch (JsonParseException e) {
+      throw new HydraFlowException("Unparseable discovery document: " + response.body(), e);
+    }
+    return new OpenIdConfiguration(
+        string(json, "issuer"),
+        endpoint(json, "authorization_endpoint", publicBaseUri),
+        endpoint(json, "token_endpoint", publicBaseUri),
+        endpoint(json, "jwks_uri", publicBaseUri),
+        endpoint(json, "userinfo_endpoint", publicBaseUri),
+        endpoint(json, "revocation_endpoint", publicBaseUri),
+        endpoint(json, "end_session_endpoint", publicBaseUri),
+        Collections.unmodifiableMap(json));
+  }
+
+  private static String string(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    return value == null ? null : value.toString();
+  }
+
+  // Re-targets an advertised endpoint at the mapped public authority, keeping the raw
+  // path/query untouched (decoding and re-encoding could corrupt encoded separators).
+  private static URI endpoint(Map<String, Object> json, String key, URI publicBaseUri) {
+    String value = string(json, key);
+    if (value == null) {
+      return null;
+    }
+    URI advertised = URI.create(value);
+    String query = advertised.getRawQuery() == null ? "" : "?" + advertised.getRawQuery();
+    return URI.create(
+        publicBaseUri.getScheme()
+            + "://"
+            + publicBaseUri.getAuthority()
+            + advertised.getRawPath()
+            + query);
+  }
+}

--- a/src/test/java/com/ardetrick/testcontainers/ArchitectureTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/ArchitectureTest.java
@@ -12,6 +12,8 @@ import com.ardetrick.testcontainers.oauth2.AuthorizationCodeFlow;
 import com.ardetrick.testcontainers.oauth2.ClientCredentialsFlow;
 import com.ardetrick.testcontainers.oauth2.FlowResult;
 import com.ardetrick.testcontainers.oauth2.HydraFlowException;
+import com.ardetrick.testcontainers.oauth2.IntrospectionResponse;
+import com.ardetrick.testcontainers.oauth2.OpenIdConfiguration;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -61,7 +63,9 @@ class ArchitectureTest {
                       AuthorizationCodeFlow.class,
                       ClientCredentialsFlow.class,
                       FlowResult.class,
-                      HydraFlowException.class)))
+                      HydraFlowException.class,
+                      IntrospectionResponse.class,
+                      OpenIdConfiguration.class)))
           .should()
           .notBePublic();
 }

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerIntrospectionAndDiscoveryTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerIntrospectionAndDiscoveryTest.java
@@ -1,0 +1,61 @@
+package com.ardetrick.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ardetrick.testcontainers.oauth2.FlowResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class OryHydraContainerIntrospectionAndDiscoveryTest {
+
+  @Test
+  public void introspectionReportsMintedTokenActiveWithSubjectAndClaims() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      var result =
+          container
+              .authorizationCodeFlow()
+              .scopes("openid")
+              .subject("introspected-user")
+              .accessTokenClaims(Map.of("dept", "engineering"))
+              .execute();
+      var token = (FlowResult.TokenResponse) result;
+
+      var introspection = container.introspect(token.accessToken());
+      assertThat(introspection.active()).isTrue();
+      assertThat(introspection.subject()).isEqualTo("introspected-user");
+      assertThat(introspection.scope()).contains("openid");
+      assertThat(introspection.clientId()).isNotBlank();
+      // Custom access-token session claims surface under "ext" — nested JSON.
+      assertThat(introspection.raw().get("ext")).isEqualTo(Map.of("dept", "engineering"));
+
+      // Unknown tokens introspect as inactive rather than throwing.
+      assertThat(container.introspect("not-a-real-token").active()).isFalse();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("removal") // asserts the deprecated helpers' documented replacements match
+  public void openIdConfigurationResolvesEndpointsOnTheMappedPort() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      var config = container.openIdConfiguration();
+
+      // Typed accessors are re-targeted at the mapped public port and must agree with the
+      // (deprecated) 0.0.5 helpers they replace.
+      assertThat(config.tokenEndpoint()).isEqualTo(container.getOAuth2TokenUri());
+      assertThat(config.authorizationEndpoint()).isEqualTo(container.getOAuth2AuthUri());
+      assertThat(config.jwksUri()).isEqualTo(container.getPublicJwksUri());
+      assertThat(config.userinfoEndpoint()).isEqualTo(container.getUserInfoUri());
+      assertThat(config.revocationEndpoint()).isEqualTo(container.getOAuth2RevokeUri());
+      assertThat(config.endSessionEndpoint()).isEqualTo(container.getOAuth2SessionsLogoutUri());
+
+      // The raw document keeps as-advertised values and nested members intact.
+      assertThat(config.issuer()).isNotBlank();
+      assertThat(config.raw().get("response_types_supported")).isInstanceOf(List.class);
+    }
+  }
+}

--- a/src/test/java/com/ardetrick/testcontainers/oauth2/JsonTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/oauth2/JsonTest.java
@@ -3,6 +3,8 @@ package com.ardetrick.testcontainers.oauth2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class JsonTest {
@@ -40,8 +42,26 @@ class JsonTest {
   }
 
   @Test
-  void rejectsNestedValues() {
-    assertThatThrownBy(() -> Json.parseObject("{\"a\":{\"b\":1}}"))
+  void parsesNestedObjectsAndArrays() {
+    var parsed =
+        Json.parseObject(
+            "{\"ext\":{\"dept\":\"eng\",\"level\":3},"
+                + "\"aud\":[\"https://api.example\",\"https://other.example\"],"
+                + "\"grant_types_supported\":[],"
+                + "\"deep\":[{\"a\":[1,2]},{\"b\":null}]}");
+
+    assertThat(parsed.get("ext")).isEqualTo(Map.of("dept", "eng", "level", 3L));
+    assertThat(parsed.get("aud"))
+        .isEqualTo(List.of("https://api.example", "https://other.example"));
+    assertThat(parsed.get("grant_types_supported")).isEqualTo(List.of());
+    assertThat(parsed.get("deep"))
+        .isEqualTo(
+            List.of(Map.of("a", List.of(1L, 2L)), java.util.Collections.singletonMap("b", null)));
+  }
+
+  @Test
+  void rejectsUnterminatedArray() {
+    assertThatThrownBy(() -> Json.parseObject("{\"a\":[1,2"))
         .isInstanceOf(JsonParseException.class);
   }
 


### PR DESCRIPTION
Adds introspect(String) — RFC 7662 introspection via the admin API, returning active/subject/scope/clientId plus the raw response with custom session claims under ext — and openIdConfiguration(), which fetches and parses the discovery document into typed endpoint accessors. Because Hydra advertises endpoints using its configured issuer, which cannot know the mapped port, the accessors are re-targeted at the mapped public authority (as-advertised values remain in raw()), making them drop-in replacements for the deprecated 0.0.5 URI helpers; the deprecation javadoc now points at them. The internal JSON reader learns nested objects and arrays to support both. A test pins the equivalence between each discovery accessor and the deprecated helper it replaces.