### PR TITLE
docs: codify API scope and design principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ Two ArchUnit rules in `ArchitectureTest` enforce the boundaries: the `oauth2` pa
 
 The library must stay framework-agnostic: no Spring or other framework dependencies in this artifact. Testing a user's real login/consent app (custom `URLS_LOGIN`/`URLS_CONSENT`, externally driven flow) is a core supported use case, guarded by `OryHydraContainerExternalLoginConsentTest` — see [ory-hydra-refrence-java](https://github.com/ardetrick/ory-hydra-refrence-java).
 
+## API Scope and Design Principles
+
+This is a test harness for real Hydra, not a Hydra client SDK. Check every proposed public addition against these principles:
+
+- **Test verbs in, admin verbs out.** A public API must answer yes to: "does a test author need this to assert something about their system under test?" In scope: minting real tokens (flows, refresh), validating tokens (introspection), resolving endpoints (discovery), and just enough client registration for a flow to run. Out of scope: operating Hydra — general client CRUD, consent-session management, JWK management. For those, users get pointed at [Ory's official Java client](https://github.com/ory/client-java) (see README), mirroring how the Keycloak Testcontainers module delegates to the official admin client rather than reimplementing one.
+- **Spec-anchored public surface, version-coupled internals quarantined.** Public types mirror the RFCs (RFC 6749 token/error responses, RFC 7662 introspection, OIDC discovery), which are stable across Hydra versions. Hydra-version-specific knowledge — admin paths, the login/consent challenge API — must stay in package-private internals so a Hydra upgrade changes this library's internals, never a user's code. Never expose hardcoded server paths publicly: the 0.0.5 URI helpers made that mistake and are deprecated for removal; endpoints are resolved from the discovery document (`openIdConfiguration()`) instead.
+- **Real responses only.** Real denials via Hydra's reject endpoints are in scope. Fabricated, forged, malformed, or expired-on-demand tokens and hand-authored error bodies are a mock server's job (e.g. navikt/mock-oauth2-server) — this library never synthesizes what real Hydra would not produce.
+- **Released API gets a deprecation cycle.** Breaking a published signature requires `@Deprecated(forRemoval = true)` with a migration pointer for at least one release before removal — never a silent break. Upgrade safety is enforced by the pinned default image, the reference-app compatibility workflows, and integration tests that pin wire behavior.
+
 ## Code Style
 
 Code is formatted with [google-java-format](https://github.com/google/google-java-format) via the [Spotless](https://github.com/diffplug/spotless) Gradle plugin. Run `./gradlew spotlessApply` after making code changes to auto-format. The `build` task includes `spotlessCheck`, so CI will reject unformatted code.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ The `OryHydraContainer` is a [Testcontainers](https://testcontainers.com) module
 * Customizable through a builder pattern, allowing configuration of the Docker image, environment variables, and wait strategy.
 * Framework-agnostic — plain JDK HTTP under the hood, no framework (or JSON library) dependencies.
 
+## Scope
+
+This library is a test harness for real Hydra, not a Hydra client SDK. In scope is what a test
+needs to assert behavior of the system under test: minting real tokens, validating them via
+introspection, and resolving endpoints. Administering Hydra — client management, consent
+sessions, JWKs — is out of scope; use [Ory's official Java client](#using-orys-official-java-client)
+for that. Also out of scope is fabricating invalid tokens or error responses: real denials
+(rejected login/consent) come from real Hydra and are fully supported, but forged, malformed, or
+expired-on-demand tokens are a mock server's job (e.g.
+[navikt/mock-oauth2-server](https://github.com/navikt/mock-oauth2-server)).
+
 ## Usage
 
 ### Dependency


### PR DESCRIPTION
States the boundary in CLAUDE.md (test verbs in, admin verbs out; spec-anchored public surface with version-coupled internals quarantined; real responses only; deprecation cycle for released API) and adds a short user-facing Scope section to the README pointing admin use cases at Ory's official client and token-forging use cases at mock servers.