### PR TITLE
feat: support public-client PKCE in the authorization-code flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ String refreshToken = token.refreshToken(); // present because "offline_access" 
 
 Options: `audience(...)` requests token audiences; `accessTokenClaims(...)`/`idTokenClaims(...)`
 target one token's session claims instead of both; `usePkce(true)` enables PKCE with the S256
-method.
+method; `publicClient(true)` runs the flow as a secret-less public client
+(`token_endpoint_auth_method: none`, PKCE implied) — the configuration mobile and single-page
+apps use.
 
 Because the tokens come from a real Hydra instance, denial paths are real too — a rejected consent
 produces Hydra's actual error redirect, not a fabricated response:

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
@@ -50,6 +50,7 @@ public final class AuthorizationCodeFlow {
   private String rejectConsentError;
   private String rejectConsentDescription;
   private boolean usePkce = false;
+  private boolean publicClient = false;
   private String redirectUri = DEFAULT_REDIRECT_URI;
 
   /**
@@ -209,6 +210,22 @@ public final class AuthorizationCodeFlow {
   }
 
   /**
+   * Runs the flow as a public client (RFC 6749 §2.1) — no client secret, {@code
+   * token_endpoint_auth_method: none} — the configuration used by mobile and single-page apps.
+   *
+   * <p>Implies PKCE (public clients must use it, RFC 8252 §8.1): the authorization request carries
+   * an S256 challenge and the token exchange sends {@code client_id} in the request body instead of
+   * HTTP Basic authentication. Must not be combined with {@link #clientSecret(String)}.
+   *
+   * @param enabled whether to run as a public client
+   * @return this flow
+   */
+  public AuthorizationCodeFlow publicClient(boolean enabled) {
+    this.publicClient = enabled;
+    return this;
+  }
+
+  /**
    * Runs the flow and returns the result.
    *
    * @return a {@link FlowResult.TokenResponse} on success, or a {@link OAuthError} if Hydra
@@ -226,7 +243,7 @@ public final class AuthorizationCodeFlow {
     resolveClient(admin);
 
     String state = UUID.randomUUID().toString();
-    String codeVerifier = usePkce ? randomUrlSafe() : null;
+    String codeVerifier = usePkce || publicClient ? randomUrlSafe() : null;
     URI current = buildAuthorizeUri(state, codeVerifier == null ? null : s256(codeVerifier));
 
     // Each hop is one of: an OAuth error, a login/consent challenge to answer via the admin API,
@@ -302,28 +319,35 @@ public final class AuthorizationCodeFlow {
   }
 
   private void resolveClient(AdminClient admin) {
+    if (publicClient && clientSecret != null) {
+      throw new HydraFlowException("public clients have no client secret");
+    }
     if (clientId != null) {
-      if (clientSecret == null) {
+      if (clientSecret == null && !publicClient) {
         throw new HydraFlowException("clientSecret must be set when clientId is provided");
       }
       return;
     }
     String id = "tc-" + UUID.randomUUID();
-    String secret = UUID.randomUUID().toString();
     Map<String, Object> registration = new LinkedHashMap<>();
     registration.put("client_id", id);
-    registration.put("client_secret", secret);
     registration.put("grant_types", List.of("authorization_code", "refresh_token"));
     registration.put("response_types", List.of("code"));
     registration.put("redirect_uris", List.of(redirectUri));
     registration.put("scope", String.join(" ", scopes));
-    registration.put("token_endpoint_auth_method", "client_secret_basic");
+    if (publicClient) {
+      registration.put("token_endpoint_auth_method", "none");
+    } else {
+      String secret = UUID.randomUUID().toString();
+      registration.put("client_secret", secret);
+      registration.put("token_endpoint_auth_method", "client_secret_basic");
+      this.clientSecret = secret;
+    }
     if (!audience.isEmpty()) {
       registration.put("audience", new ArrayList<>(audience));
     }
     admin.createClient(registration);
     this.clientId = id;
-    this.clientSecret = secret;
   }
 
   private Map<String, Object> session() {

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
@@ -27,7 +27,11 @@ final class TokenEndpointClient {
     return post(tokenEndpoint, form.toString(), clientId, clientSecret);
   }
 
-  /** Authorization-code exchange (RFC 6749 §4.1.3) using {@code client_secret_basic}. */
+  /**
+   * Authorization-code exchange (RFC 6749 §4.1.3) using {@code client_secret_basic}, or — when
+   * {@code clientSecret} is {@code null} (public client) — {@code client_id} in the request body
+   * with no client authentication.
+   */
   static FlowResult authorizationCode(
       URI tokenEndpoint,
       String clientId,
@@ -46,22 +50,27 @@ final class TokenEndpointClient {
 
   private static FlowResult post(
       URI tokenEndpoint, String form, String clientId, String clientSecret) {
-    // RFC 6749 §2.3.1: client id and secret are form-urlencoded before being concatenated
-    // and Base64-encoded, so secrets containing ':' or '%' authenticate correctly.
-    String credentials =
-        Base64.getEncoder()
-            .encodeToString(
-                (Http.encode(clientId) + ":" + Http.encode(clientSecret))
-                    .getBytes(StandardCharsets.UTF_8));
+    HttpRequest.Builder request =
+        HttpRequest.newBuilder(tokenEndpoint)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Accept", "application/json");
+    if (clientSecret == null) {
+      // Public client (RFC 6749 §2.1): no authentication, client_id in the request body.
+      form = form + "&client_id=" + Http.encode(clientId);
+    } else {
+      // RFC 6749 §2.3.1: client id and secret are form-urlencoded before being concatenated
+      // and Base64-encoded, so secrets containing ':' or '%' authenticate correctly.
+      String credentials =
+          Base64.getEncoder()
+              .encodeToString(
+                  (Http.encode(clientId) + ":" + Http.encode(clientSecret))
+                      .getBytes(StandardCharsets.UTF_8));
+      request.header("Authorization", "Basic " + credentials);
+    }
     HttpResponse<String> response =
         Http.send(
             HttpClient.newHttpClient(),
-            HttpRequest.newBuilder(tokenEndpoint)
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .header("Authorization", "Basic " + credentials)
-                .header("Accept", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(form))
-                .build());
+            request.POST(HttpRequest.BodyPublishers.ofString(form)).build());
 
     Map<String, Object> json;
     try {

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
@@ -98,6 +98,22 @@ public class OryHydraContainerAuthorizationCodeFlowTest {
   }
 
   @Test
+  public void publicClientFlowWithImpliedPkceSucceeds() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+
+      FlowResult result =
+          container.authorizationCodeFlow().scopes("openid").publicClient(true).execute();
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      var token = (FlowResult.TokenResponse) result;
+      assertThat(token.accessToken()).isNotBlank();
+      // The secret-less client's token is real and active.
+      assertThat(container.introspect(token.accessToken()).active()).isTrue();
+    }
+  }
+
+  @Test
   public void authorizationCodeFlowWithPreRegisteredClientSucceeds() throws Exception {
     try (var container = OryHydraContainer.builder().build()) {
       container.start();


### PR DESCRIPTION
Adds publicClient(true), which registers the ephemeral client with token_endpoint_auth_method: none and no secret — the configuration mobile and single-page apps use — and implies PKCE per RFC 8252 §8.1. The token exchange then sends client_id in the request body instead of HTTP Basic authentication. A pre-registered public client can be used via clientId() without clientSecret(). Closes the gap where PKCE could only be exercised with confidential clients.