### PR TITLE
feat: add refresh-token support to the authorization-code flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ method; `publicClient(true)` runs the flow as a secret-less public client
 (`token_endpoint_auth_method: none`, PKCE implied) — the configuration mobile and single-page
 apps use.
 
+The flow instance can also exchange a refresh token it minted (RFC 6749 §6), reusing the same
+client — ephemeral or supplied:
+
+```java
+var flow = hydra.authorizationCodeFlow().scopes("openid", "offline_access");
+var tokens = (FlowResult.TokenResponse) flow.execute();
+var refreshed = (FlowResult.TokenResponse) flow.refresh(tokens.refreshToken());
+```
+
 Because the tokens come from a real Hydra instance, denial paths are real too — a rejected consent
 produces Hydra's actual error redirect, not a fabricated response:
 

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/AuthorizationCodeFlow.java
@@ -271,6 +271,28 @@ public final class AuthorizationCodeFlow {
         "Authorization code not received within " + MAX_HOPS + " redirects");
   }
 
+  /**
+   * Exchanges a refresh token for a new token pair (RFC 6749 §6) using this flow's client.
+   *
+   * <p>Call after {@link #execute()} so this flow's client — ephemeral or supplied — is resolved,
+   * or pre-set {@link #clientId(String)} (and {@link #clientSecret(String)}, unless {@link
+   * #publicClient(boolean)}) to refresh a token minted elsewhere by that client.
+   *
+   * @param refreshToken the refresh token to exchange
+   * @return a {@link FlowResult.TokenResponse} on success, or a {@link OAuthError} (e.g. {@code
+   *     invalid_grant} for an unknown, expired, or already-rotated refresh token)
+   * @throws HydraFlowException if no client is resolved or the request cannot be completed
+   */
+  public FlowResult refresh(String refreshToken) {
+    if (clientId == null) {
+      throw new HydraFlowException(
+          "No client resolved: call execute() first, or set clientId() to refresh with a known"
+              + " client");
+    }
+    return TokenEndpointClient.refreshToken(
+        publicBaseUri.resolve("/oauth2/token"), clientId, clientSecret, refreshToken);
+  }
+
   private static URI followRedirect(HttpClient http, URI current) {
     HttpResponse<String> response = Http.send(http, HttpRequest.newBuilder(current).GET().build());
     if (!Http.is3xx(response.statusCode())) {

--- a/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
+++ b/src/main/java/com/ardetrick/testcontainers/oauth2/TokenEndpointClient.java
@@ -27,6 +27,13 @@ final class TokenEndpointClient {
     return post(tokenEndpoint, form.toString(), clientId, clientSecret);
   }
 
+  /** Refresh-token grant (RFC 6749 §6), authenticated like the code exchange below. */
+  static FlowResult refreshToken(
+      URI tokenEndpoint, String clientId, String clientSecret, String refreshToken) {
+    String form = "grant_type=refresh_token&refresh_token=" + Http.encode(refreshToken);
+    return post(tokenEndpoint, form, clientId, clientSecret);
+  }
+
   /**
    * Authorization-code exchange (RFC 6749 §4.1.3) using {@code client_secret_basic}, or — when
    * {@code clientSecret} is {@code null} (public client) — {@code client_id} in the request body

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
@@ -98,6 +98,26 @@ public class OryHydraContainerAuthorizationCodeFlowTest {
   }
 
   @Test
+  public void refreshTokenGrantIssuesNewUsableTokens() {
+    try (var container = OryHydraContainer.builder().build()) {
+      container.start();
+      var flow = container.authorizationCodeFlow().scopes("openid", "offline_access");
+      var tokens = (FlowResult.TokenResponse) flow.execute();
+
+      var result = flow.refresh(tokens.refreshToken());
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      var refreshed = (FlowResult.TokenResponse) result;
+      assertThat(refreshed.accessToken()).isNotBlank().isNotEqualTo(tokens.accessToken());
+      assertThat(refreshed.refreshToken()).isNotBlank();
+      assertThat(container.introspect(refreshed.accessToken()).active()).isTrue();
+
+      // An unknown refresh token is a protocol error value, not an exception.
+      assertThat(flow.refresh("garbage-refresh-token")).isInstanceOf(FlowResult.OAuthError.class);
+    }
+  }
+
+  @Test
   public void publicClientFlowWithImpliedPkceSucceeds() {
     try (var container = OryHydraContainer.builder().build()) {
       container.start();


### PR DESCRIPTION
Adds refresh(String) on AuthorizationCodeFlow (RFC 6749 §6), reusing the flow's resolved client — ephemeral or supplied, confidential or public — so the common mint-then-refresh test needs no credential plumbing. Unknown or rotated refresh tokens return an OAuthError value; calling refresh with no resolved client fails fast. A standalone refresh builder for tokens minted outside a flow is deliberately deferred until demanded.