### PR TITLE
test: guard and document container-to-container networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,27 @@ at the container — `getOpenIdDiscoveryUri()` for discovery-based setups, or
 `publicBaseUriString()`/`getOAuth2TokenUri()` for individual endpoints — and feed it a token minted
 by one of the flows above.
 
+#### When your application under test also runs in Docker
+
+Put Hydra and your application on the same Docker network, give Hydra an alias, and set the
+issuer to the alias-based URL so in-network consumers resolve endpoints they can actually reach:
+
+```java
+Network network = Network.newNetwork();
+OryHydraContainer hydra = OryHydraContainer.builder()
+        .urlsSelfIssuer("http://hydra:4444")
+        .build()
+        .withNetwork(network)
+        .withNetworkAliases("hydra");
+```
+
+Inside the network, your application reaches Hydra at `http://hydra:4444` (public) and
+`http://hydra:4445` (admin) — the internal ports, no mapping involved. From the host, everything
+above keeps working unchanged: the flow helpers rewrite Hydra's redirects to the mapped port
+regardless of the configured issuer, so you can mint a token on the host and have your dockerized
+resource server validate it in-network. This setup is guarded by
+`OryHydraContainerDockerNetworkTest`.
+
 ### Custom Configuration
 
 ```java

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerDockerNetworkTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerDockerNetworkTest.java
@@ -1,0 +1,66 @@
+package com.ardetrick.testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ardetrick.testcontainers.oauth2.FlowResult;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+
+/**
+ * Guards the container-to-container setup documented in the README: Hydra joins a Docker network
+ * under an alias with {@code URLS_SELF_ISSUER} set to the alias-based URL, an in-network consumer
+ * (standing in for a dockerized app under test) reaches Hydra by alias on the unmapped internal
+ * ports, and the host-side flow helpers keep working despite the custom issuer because they rewrite
+ * every Hydra-bound redirect to the mapped port.
+ */
+public class OryHydraContainerDockerNetworkTest {
+
+  @Test
+  public void inNetworkConsumerAndHostFlowsBothWorkWithAliasIssuer() throws Exception {
+    try (var network = Network.newNetwork();
+        var hydra =
+            OryHydraContainer.builder()
+                .urlsSelfIssuer("http://hydra:4444")
+                .build()
+                .withNetwork(network)
+                .withNetworkAliases("hydra")) {
+      hydra.start();
+
+      // Host-side minting still works: the flow driver rewrites Hydra-bound redirects to the
+      // mapped port regardless of the configured issuer.
+      var result = hydra.authorizationCodeFlow().scopes("openid").execute();
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      var token = (FlowResult.TokenResponse) result;
+
+      try (var appUnderTest =
+          new GenericContainer<>("curlimages/curl:8.11.1")
+              .withNetwork(network)
+              .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("sleep", "300"))) {
+        appUnderTest.start();
+
+        // The in-network consumer resolves the discovery document by alias, and the advertised
+        // issuer is the alias URL it can actually reach.
+        var discovery =
+            appUnderTest.execInContainer(
+                "curl", "-s", "http://hydra:4444/.well-known/openid-configuration");
+        assertThat(discovery.getExitCode()).isZero();
+        assertThat(discovery.getStdout()).contains("\"issuer\":\"http://hydra:4444");
+
+        // A token minted from the host validates inside the network — the handoff a dockerized
+        // resource server under test performs.
+        var introspection =
+            appUnderTest.execInContainer(
+                "curl",
+                "-s",
+                "-X",
+                "POST",
+                "-d",
+                "token=" + token.accessToken(),
+                "http://hydra:4445/admin/oauth2/introspect");
+        assertThat(introspection.getExitCode()).isZero();
+        assertThat(introspection.getStdout()).contains("\"active\":true");
+      }
+    }
+  }
+}


### PR DESCRIPTION
Documents the Docker-network pattern — Hydra on a shared network under an alias, URLS_SELF_ISSUER set to the alias-based URL — and adds a regression test in which an in-network consumer resolves the discovery document by alias and validates a host-minted token via introspection, while the host-side flow helpers keep working despite the custom issuer. No new API: withNetwork/withNetworkAliases are inherited from GenericContainer and the builder already covers the issuer.