### PR TITLE
feat: support mid-test client registration with a customizer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,28 +263,35 @@ once:
 ```java
 @Container
 static OryHydraContainer hydra = OryHydraContainer.builder()
-        .client(OAuth2ClientRegistration.create()
+        .client(client -> client
                 .clientId("my-app")
                 .clientSecret("my-secret")
                 .grantTypes("authorization_code", "refresh_token")
                 .responseTypes("code")
                 .redirectUris("https://app.example/callback")
-                .scope("openid", "offline_access")
-                .toMap())
+                .scope("openid", "offline_access"))
         .build();
 ```
 
-`OAuth2ClientRegistration` covers the standard RFC 7591 metadata fields with typed methods;
-anything else — including Hydra-specific fields — can be set with `put(key, value)`/`putAll(map)`,
-which also override typed values explicitly. A plain `Map` works everywhere a registration is
-accepted.
+The customizer receives an `OAuth2ClientRegistration`, whose typed methods cover the standard
+RFC 7591 metadata fields; anything else — including Hydra-specific fields — can be set with
+`put(key, value)`/`putAll(map)`, which also override typed values explicitly. A plain `Map` of
+Hydra client JSON works everywhere a registration is accepted.
 
-Clients can also be registered after startup with `createOAuth2Client`, which uses the Hydra CLI
-inside the container:
+Clients can also be registered on the running container mid-test — useful when a shared container
+serves many test classes and a class brings its own client. Registration is an upsert (matched by
+`client_id`), so re-runs converge instead of failing on duplicates:
 
 ```java
-hydra.createOAuth2Client("my-client", "my-secret", List.of("http://localhost/callback"));
+hydra.createOrReplaceClient(client -> client
+        .clientId("my-service")
+        .clientSecret("my-secret")
+        .grantTypes("client_credentials")
+        .scope("read"));
 ```
+
+The CLI-based `createOAuth2Client(id, secret, redirectUris)` is deprecated in favor of the
+methods above and scheduled for removal.
 
 ## Convenience URI Methods
 

--- a/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
+++ b/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -139,7 +140,11 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
    * @throws IOException if an I/O error occurs communicating with the container
    * @throws InterruptedException if the thread is interrupted while waiting for the command
    * @throws IllegalStateException if the Hydra CLI exits with a non-zero status
+   * @deprecated use {@link #createOrReplaceClient(Consumer)} (or the {@code Map} overload) for
+   *     full-featured, upserting registration, or declare fixtures via {@link
+   *     Builder#client(Consumer)}; scheduled for removal.
    */
+  @Deprecated(since = "0.0.6", forRemoval = true)
   public void createOAuth2Client(String clientId, String clientSecret, List<String> redirectUris)
       throws IOException, InterruptedException {
     Objects.requireNonNull(clientId, "clientId must not be null");
@@ -169,6 +174,41 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
               + "): "
               + result.getStderr());
     }
+  }
+
+  /**
+   * Registers an OAuth 2.0 client on the running container, or replaces the existing client with
+   * the same {@code client_id} — an upsert, so re-running test classes against a shared container
+   * converge on the declared state instead of failing on duplicates.
+   *
+   * <p>The map is Hydra's client JSON, passed through verbatim (any field Hydra accepts works;
+   * nested values are allowed); it must contain {@code client_id}.
+   *
+   * @param registration Hydra client JSON as a map, including {@code client_id}
+   */
+  public void createOrReplaceClient(Map<String, Object> registration) {
+    OAuth2Clients.createOrReplace(URI.create(adminBaseUriString()), registration);
+  }
+
+  /**
+   * Registers an OAuth 2.0 client on the running container using the typed registration builder —
+   * or replaces the existing client with the same {@code client_id} (an upsert).
+   *
+   * <pre>{@code
+   * hydra.createOrReplaceClient(client -> client
+   *     .clientId("my-app")
+   *     .clientSecret("my-secret")
+   *     .grantTypes("client_credentials"));
+   * }</pre>
+   *
+   * @param customizer receives a fresh {@link OAuth2ClientRegistration} to populate; must set
+   *     {@code client_id}
+   */
+  public void createOrReplaceClient(Consumer<OAuth2ClientRegistration> customizer) {
+    Objects.requireNonNull(customizer, "customizer must not be null");
+    OAuth2ClientRegistration registration = OAuth2ClientRegistration.create();
+    customizer.accept(registration);
+    createOrReplaceClient(registration.toMap());
   }
 
   /**
@@ -524,6 +564,32 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
       Objects.requireNonNull(registration, "registration must not be null");
       this.clients.add(new LinkedHashMap<>(registration));
       return this;
+    }
+
+    /**
+     * Declares an OAuth 2.0 client fixture using the typed registration builder — equivalent to
+     * {@link #client(Map)} with the customized registration's map.
+     *
+     * <pre>{@code
+     * OryHydraContainer.builder()
+     *     .client(client -> client
+     *         .clientId("my-app")
+     *         .clientSecret("my-secret")
+     *         .grantTypes("authorization_code", "refresh_token")
+     *         .responseTypes("code")
+     *         .redirectUris("https://app.example/callback"))
+     *     .build();
+     * }</pre>
+     *
+     * @param customizer receives a fresh {@link OAuth2ClientRegistration} to populate; must set
+     *     {@code client_id}
+     * @return this builder for chaining
+     */
+    public Builder client(Consumer<OAuth2ClientRegistration> customizer) {
+      Objects.requireNonNull(customizer, "customizer must not be null");
+      OAuth2ClientRegistration registration = OAuth2ClientRegistration.create();
+      customizer.accept(registration);
+      return client(registration.toMap());
     }
 
     /**

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerClientFixturesTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerClientFixturesTest.java
@@ -2,7 +2,6 @@ package com.ardetrick.testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -21,15 +20,15 @@ public class OryHydraContainerClientFixturesTest {
                     "token_endpoint_auth_method", "client_secret_basic",
                     "scope", "read"))
             .client(
-                OAuth2ClientRegistration.create()
-                    .clientId("fixture-web-app")
-                    .clientSecret("web-secret")
-                    .grantTypes("authorization_code", "refresh_token")
-                    .responseTypes("code")
-                    .redirectUris("http://localhost/callback")
-                    .tokenEndpointAuthMethod("client_secret_basic")
-                    .scope("openid")
-                    .toMap())
+                client ->
+                    client
+                        .clientId("fixture-web-app")
+                        .clientSecret("web-secret")
+                        .grantTypes("authorization_code", "refresh_token")
+                        .responseTypes("code")
+                        .redirectUris("http://localhost/callback")
+                        .tokenEndpointAuthMethod("client_secret_basic")
+                        .scope("openid"))
             .build()) {
       container.start();
 
@@ -52,10 +51,28 @@ public class OryHydraContainerClientFixturesTest {
               .execute();
       assertThat(userToken).isInstanceOf(FlowResult.TokenResponse.class);
 
-      // Redeclaring an existing client_id upserts instead of failing — the property that makes
-      // fixtures safe for restarted or reused containers.
-      OAuth2Clients.createOrReplace(
-          URI.create(container.adminBaseUriString()),
+      // Mid-test registration on the running container: a client that was not declared
+      // up front becomes usable immediately — the shared-container use case.
+      container.createOrReplaceClient(
+          client ->
+              client
+                  .clientId("mid-test-app")
+                  .clientSecret("mid-test-secret")
+                  .grantTypes("client_credentials")
+                  .tokenEndpointAuthMethod("client_secret_basic")
+                  .scope("read"));
+      var midTest =
+          container
+              .clientCredentialsFlow()
+              .clientId("mid-test-app")
+              .clientSecret("mid-test-secret")
+              .scopes("read")
+              .execute();
+      assertThat(midTest).isInstanceOf(FlowResult.TokenResponse.class);
+
+      // Re-registering an existing client_id upserts instead of failing — the property that makes
+      // registration safe for restarted, reused, or re-run shared containers.
+      container.createOrReplaceClient(
           Map.of(
               "client_id", "fixture-service",
               "client_secret", "rotated-secret",

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerTest.java
@@ -74,6 +74,7 @@ public class OryHydraContainerTest {
   }
 
   @Test
+  @SuppressWarnings("removal") // pins the deprecated CLI helper until its removal release
   public void createOAuth2ClientSucceeds() throws Exception {
     try (var container = OryHydraContainer.builder().build()) {
       container.start();


### PR DESCRIPTION
Adds createOrReplaceClient on the container — a Consumer< OAuth2ClientRegistration> customizer overload (typed fields by default, put/putAll as the escape hatch) and a raw Map overload — backed by the same upserting registration as declarative fixtures, so re-running test classes against a shared container converges instead of failing on duplicates. Builder.client gains the matching customizer overload so pre-start and mid-test registration read identically. The CLI-based createOAuth2Client is deprecated (since 0.0.6, for removal): it covers only three fields and parses exec output where the admin API returns structured errors.