### PR TITLE
ci: smoke-check the jreleaser classpath on every build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,3 +31,16 @@ jobs:
           cache: 'gradle'
       - name: build
         run: ./gradlew build --no-daemon
+      # Catches buildscript classpath conflicts (e.g. the Spotless/JReleaser JGit collision,
+      # https://github.com/jreleaser/jreleaser/issues/1643) that otherwise surface only when
+      # release tasks run on publish day. The dummy values satisfy config validation; no
+      # release operation is performed.
+      - name: jreleaser classpath smoke check
+        env:
+          JRELEASER_GITHUB_TOKEN: smoke
+          JRELEASER_MAVENCENTRAL_USERNAME: smoke
+          JRELEASER_MAVENCENTRAL_PASSWORD: smoke
+          JRELEASER_GPG_PASSPHRASE: smoke
+          JRELEASER_GPG_PUBLIC_KEY: smoke
+          JRELEASER_GPG_SECRET_KEY: smoke
+        run: ./gradlew jreleaserConfig --no-daemon

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,12 @@
 buildscript {
     configurations.classpath {
         resolutionStrategy {
-            // Fix https://github.com/jreleaser/jreleaser/issues/1643
-            force("org.eclipse.jgit:org.eclipse.jgit:7.7.0.202606012155-r")
+            // Spotless and JReleaser request conflicting JGit majors on the shared buildscript
+            // classpath (https://github.com/jreleaser/jreleaser/issues/1643). Pin JReleaser's own
+            // version: JGit 7 removed the GpgObjectSigner API JReleaser needs, while Spotless only
+            // uses JGit for ratchetFrom, which this build does not use. Guarded by the
+            // "jreleaser classpath smoke check" CI step.
+            force("org.eclipse.jgit:org.eclipse.jgit:5.13.5.202508271544-r")
         }
     }
 }


### PR DESCRIPTION
Runs jreleaserConfig with dummy credentials so buildscript classpath conflicts — like the Spotless/JReleaser JGit collision that currently breaks jreleaserFullRelease — fail dependabot PRs instead of surfacing on publish day.