### PR TITLE
fix: skip git tagging in jreleaser and modernize signing config

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -6,11 +6,16 @@ project:
 
 release:
   github:
+    # Releasing and tagging are performed manually (tag + GitHub Release created after
+    # Maven Central propagation); JReleaser must not touch git — its bundled JGit cannot
+    # authenticate with modern GitHub SSH setups anyway.
     skipRelease: true
+    skipTag: true
 
 signing:
   active: ALWAYS
-  armored: true
+  pgp:
+    armored: true
 
 deploy:
   maven:


### PR DESCRIPTION
skipRelease only skips the GitHub release object — jreleaserFullRelease still tried to push the tag itself, over SSH via its bundled JGit 5.13, whose JSch transport cannot authenticate with modern GitHub SSH setups (remote hung up unexpectedly). Tagging and the GitHub Release are performed manually after Maven Central propagation, so skipTag aligns the tool with the actual process. Also moves signing.armored to signing.pgp.armored, resolving the deprecation slated for removal in JReleaser 2.0.