### PR TITLE
fix: strip issuer path prefixes when re-targeting issuer-derived URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ at the container — `getOpenIdDiscoveryUri()` for discovery-based setups, or
 `publicBaseUriString()`/`getOAuth2TokenUri()` for individual endpoints — and feed it a token minted
 by one of the flows above.
 
+A path-bearing issuer — mirroring Hydra behind a production gateway, e.g.
+`urlsSelfIssuer("https://api.example.com/auth")` — is fully supported: minted tokens carry that
+issuer, while the flow driver and the `openIdConfiguration()` accessors strip the gateway's path
+prefix so every URL they produce stays reachable on the mapped port (`raw()` keeps the
+as-advertised values). For full fidelity including the gateway itself, run a proxy container on a
+shared Docker network (see below) and point the issuer at its alias.
+
 #### When your application under test also runs in Docker
 
 Put Hydra and your application on the same Docker network, give Hydra an alias, and set the

--- a/src/main/java/com/ardetrick/testcontainers/AuthorizationCodeFlow.java
+++ b/src/main/java/com/ardetrick/testcontainers/AuthorizationCodeFlow.java
@@ -245,6 +245,10 @@ public final class AuthorizationCodeFlow {
     String state = UUID.randomUUID().toString();
     String codeVerifier = usePkce || publicClient ? randomUrlSafe() : null;
     URI current = buildAuthorizeUri(state, codeVerifier == null ? null : s256(codeVerifier));
+    // A path-bearing issuer (Hydra behind a gateway in production) prefixes every issuer-derived
+    // redirect with a path the container does not serve; learn it once so rewrites can strip it.
+    String issuerPathPrefix =
+        OpenIdConfiguration.issuerPathPrefix(OpenIdConfiguration.fetch(publicBaseUri).issuer());
 
     // Each hop is one of: an OAuth error, a login/consent challenge to answer via the admin API,
     // the client callback carrying the code, or another Hydra-bound redirect to follow.
@@ -257,13 +261,13 @@ public final class AuthorizationCodeFlow {
             query.get("error"), query.get("error_description"), query.get("error_uri"));
       }
       if (query.containsKey("login_challenge")) {
-        current = rewrite(answerLogin(admin, query.get("login_challenge")));
+        current = rewrite(answerLogin(admin, query.get("login_challenge")), issuerPathPrefix);
       } else if (query.containsKey("consent_challenge")) {
-        current = rewrite(answerConsent(admin, query.get("consent_challenge")));
+        current = rewrite(answerConsent(admin, query.get("consent_challenge")), issuerPathPrefix);
       } else if (isRedirectUri(location)) {
         return exchangeCode(query, state, codeVerifier);
       } else {
-        current = rewrite(location);
+        current = rewrite(location, issuerPathPrefix);
       }
     }
 
@@ -408,18 +412,8 @@ public final class AuthorizationCodeFlow {
         && Objects.equals(redirect.getPath(), location.getPath());
   }
 
-  // Swaps in the mapped authority while keeping the raw path/query untouched: decoding and
-  // re-encoding could corrupt values that legitimately contain encoded separators.
-  private URI rewrite(URI location) {
-    String query = location.getRawQuery() == null ? "" : "?" + location.getRawQuery();
-    String fragment = location.getRawFragment() == null ? "" : "#" + location.getRawFragment();
-    return URI.create(
-        publicBaseUri.getScheme()
-            + "://"
-            + publicBaseUri.getAuthority()
-            + location.getRawPath()
-            + query
-            + fragment);
+  private URI rewrite(URI location, String issuerPathPrefix) {
+    return OpenIdConfiguration.retarget(location, issuerPathPrefix, publicBaseUri);
   }
 
   private static Map<String, String> parseQuery(String rawQuery) {

--- a/src/main/java/com/ardetrick/testcontainers/OpenIdConfiguration.java
+++ b/src/main/java/com/ardetrick/testcontainers/OpenIdConfiguration.java
@@ -13,8 +13,9 @@ import java.util.Map;
  *
  * <p>The document advertises endpoints using Hydra's configured issuer, which cannot know the
  * container's dynamically mapped port — so each endpoint accessor is re-targeted at the mapped
- * public host and port and is directly usable from the test. The as-advertised values are preserved
- * in {@link #raw()}.
+ * public host and port (any issuer path prefix is stripped, since Hydra serves its routes at the
+ * root of its port) and is directly usable from the test. The as-advertised values are preserved in
+ * {@link #raw()}.
  *
  * @param issuer the advertised issuer identifier, as-is (not re-targeted)
  * @param authorizationEndpoint the OAuth 2.0 authorization endpoint, or {@code null} if absent
@@ -80,19 +81,39 @@ public record OpenIdConfiguration(
   }
 
   // Re-targets an advertised endpoint at the mapped public authority, keeping the raw
-  // path/query untouched (decoding and re-encoding could corrupt encoded separators).
+  // path/query untouched (decoding and re-encoding could corrupt encoded separators) — except
+  // that the configured issuer's path prefix is stripped: a path-bearing issuer (e.g.
+  // http://gateway.example/hydra) makes Hydra advertise endpoints under a prefix it does not
+  // itself serve, so keeping it would produce URIs that 404 against the container.
   private static URI endpoint(Map<String, Object> json, String key, URI publicBaseUri) {
     String value = string(json, key);
     if (value == null) {
       return null;
     }
     URI advertised = URI.create(value);
+    String path = advertised.getRawPath() == null ? "" : advertised.getRawPath();
+    String issuerPath = issuerPath(json);
+    if (!issuerPath.isEmpty() && path.startsWith(issuerPath)) {
+      path = path.substring(issuerPath.length());
+    }
+    if (!path.startsWith("/")) {
+      path = "/" + path;
+    }
     String query = advertised.getRawQuery() == null ? "" : "?" + advertised.getRawQuery();
     return URI.create(
-        publicBaseUri.getScheme()
-            + "://"
-            + publicBaseUri.getAuthority()
-            + advertised.getRawPath()
-            + query);
+        publicBaseUri.getScheme() + "://" + publicBaseUri.getAuthority() + path + query);
+  }
+
+  private static String issuerPath(Map<String, Object> json) {
+    String issuer = string(json, "issuer");
+    if (issuer == null) {
+      return "";
+    }
+    String path = URI.create(issuer).getRawPath();
+    if (path == null || path.isEmpty() || path.equals("/")) {
+      return "";
+    }
+    // Normalize a trailing slash so an issuer of ".../prefix/" strips the same as ".../prefix".
+    return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
   }
 }

--- a/src/main/java/com/ardetrick/testcontainers/OpenIdConfiguration.java
+++ b/src/main/java/com/ardetrick/testcontainers/OpenIdConfiguration.java
@@ -80,32 +80,23 @@ public record OpenIdConfiguration(
     return value == null ? null : value.toString();
   }
 
-  // Re-targets an advertised endpoint at the mapped public authority, keeping the raw
-  // path/query untouched (decoding and re-encoding could corrupt encoded separators) — except
-  // that the configured issuer's path prefix is stripped: a path-bearing issuer (e.g.
-  // http://gateway.example/hydra) makes Hydra advertise endpoints under a prefix it does not
-  // itself serve, so keeping it would produce URIs that 404 against the container.
   private static URI endpoint(Map<String, Object> json, String key, URI publicBaseUri) {
     String value = string(json, key);
     if (value == null) {
       return null;
     }
-    URI advertised = URI.create(value);
-    String path = advertised.getRawPath() == null ? "" : advertised.getRawPath();
-    String issuerPath = issuerPath(json);
-    if (!issuerPath.isEmpty() && path.startsWith(issuerPath)) {
-      path = path.substring(issuerPath.length());
-    }
-    if (!path.startsWith("/")) {
-      path = "/" + path;
-    }
-    String query = advertised.getRawQuery() == null ? "" : "?" + advertised.getRawQuery();
-    return URI.create(
-        publicBaseUri.getScheme() + "://" + publicBaseUri.getAuthority() + path + query);
+    return retarget(URI.create(value), issuerPathPrefix(string(json, "issuer")), publicBaseUri);
   }
 
-  private static String issuerPath(Map<String, Object> json) {
-    String issuer = string(json, "issuer");
+  // Shared by the authorization-code flow driver so the two issuer-to-container translation
+  // layers cannot drift apart.
+
+  /**
+   * Extracts the path prefix of the given issuer, or {@code ""} when the issuer has none — a
+   * path-bearing issuer (e.g. {@code http://gateway.example/hydra}) makes Hydra advertise endpoints
+   * and issue redirects under a prefix it does not itself serve.
+   */
+  static String issuerPathPrefix(String issuer) {
     if (issuer == null) {
       return "";
     }
@@ -115,5 +106,24 @@ public record OpenIdConfiguration(
     }
     // Normalize a trailing slash so an issuer of ".../prefix/" strips the same as ".../prefix".
     return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+  }
+
+  /**
+   * Re-targets an issuer-derived URI at the mapped public authority: swaps in the authority, strips
+   * the issuer's path prefix, and keeps the raw path/query/fragment otherwise untouched (decoding
+   * and re-encoding could corrupt encoded separators).
+   */
+  static URI retarget(URI advertised, String issuerPathPrefix, URI publicBaseUri) {
+    String path = advertised.getRawPath() == null ? "" : advertised.getRawPath();
+    if (!issuerPathPrefix.isEmpty() && path.startsWith(issuerPathPrefix)) {
+      path = path.substring(issuerPathPrefix.length());
+    }
+    if (!path.startsWith("/")) {
+      path = "/" + path;
+    }
+    String query = advertised.getRawQuery() == null ? "" : "?" + advertised.getRawQuery();
+    String fragment = advertised.getRawFragment() == null ? "" : "#" + advertised.getRawFragment();
+    return URI.create(
+        publicBaseUri.getScheme() + "://" + publicBaseUri.getAuthority() + path + query + fragment);
   }
 }

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerAuthorizationCodeFlowTest.java
@@ -171,6 +171,28 @@ public class OryHydraContainerAuthorizationCodeFlowTest {
   }
 
   @Test
+  public void authorizationCodeFlowWorksWithPathBearingIssuer() {
+    try (var container =
+        OryHydraContainer.builder().urlsSelfIssuer("http://gateway.example/auth-prefix").build()) {
+      container.start();
+
+      // Every issuer-derived redirect carries the /auth-prefix path the container does not
+      // serve; the driver must strip it while following the flow.
+      FlowResult result = container.authorizationCodeFlow().scopes("openid").execute();
+
+      assertThat(result).isInstanceOf(FlowResult.TokenResponse.class);
+      var token = (FlowResult.TokenResponse) result;
+      // The minted token carries the configured issuer — the reason a test mirrors a
+      // gateway-prefixed production issuer in the first place.
+      var idTokenPayload =
+          new String(
+              Base64.getUrlDecoder().decode(token.idToken().split("\\.")[1]),
+              StandardCharsets.UTF_8);
+      assertThat(idTokenPayload).contains("\"iss\":\"http://gateway.example/auth-prefix");
+    }
+  }
+
+  @Test
   public void rejectedLoginReturnsOAuthError() {
     try (var container = OryHydraContainer.builder().build()) {
       container.start();

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerIntrospectionAndDiscoveryTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerIntrospectionAndDiscoveryTest.java
@@ -36,6 +36,25 @@ public class OryHydraContainerIntrospectionAndDiscoveryTest {
   }
 
   @Test
+  public void openIdConfigurationStripsPathBearingIssuerPrefix() {
+    try (var container =
+        OryHydraContainer.builder().urlsSelfIssuer("http://gateway.example/hydra-prefix").build()) {
+      container.start();
+
+      var config = container.openIdConfiguration();
+
+      // Advertised values carry the issuer's path prefix, which nothing on the container serves...
+      assertThat(config.issuer()).startsWith("http://gateway.example/hydra-prefix");
+      assertThat(String.valueOf(config.raw().get("jwks_uri"))).contains("/hydra-prefix/");
+      // ...so the accessors strip it, staying directly usable against the mapped port.
+      assertThat(config.jwksUri())
+          .hasToString(container.publicBaseUriString() + "/.well-known/jwks.json");
+      assertThat(config.authorizationEndpoint())
+          .hasToString(container.publicBaseUriString() + "/oauth2/auth");
+    }
+  }
+
+  @Test
   @SuppressWarnings("removal") // asserts the deprecated helpers' documented replacements match
   public void openIdConfigurationResolvesEndpointsOnTheMappedPort() {
     try (var container = OryHydraContainer.builder().build()) {


### PR DESCRIPTION
A path-bearing URLS_SELF_ISSUER (mirroring Hydra behind a production gateway, set for iss-claim fidelity) made issuer-derived URLs carry a path prefix the container does not serve: the openIdConfiguration() accessors returned URIs that 404, and the authorization-code flow driver failed the same way on every issuer-derived redirect hop. Both translation layers now strip the issuer's path prefix via a shared retarget helper (the driver learns the prefix from one discovery fetch per execute()); raw() keeps the as-advertised values. Found by migrating the reference implementation, whose synthetic issuer carries a path; covered by container tests with a gateway-style prefixed issuer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)