### PR TITLE
chore: adopt a Gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,8 @@ buildscript {
             // classpath (https://github.com/jreleaser/jreleaser/issues/1643). Pin JReleaser's own
             // version: JGit 7 removed the GpgObjectSigner API JReleaser needs, while Spotless only
             // uses JGit for ratchetFrom, which this build does not use. Guarded by the
-            // "jreleaser classpath smoke check" CI step.
+            // "jreleaser classpath smoke check" CI step. Kept as a literal because version-catalog
+            // accessors are not available inside the buildscript block.
             force("org.eclipse.jgit:org.eclipse.jgit:5.13.5.202508271544-r")
         }
     }
@@ -14,16 +15,16 @@ buildscript {
 plugins {
     `maven-publish`
     `java-library`
-    id("io.freefair.lombok") version "9.5.0"
-    id("org.jreleaser") version "1.25.0"
-    id("com.diffplug.spotless") version "8.7.0"
+    alias(libs.plugins.freefair.lombok)
+    alias(libs.plugins.jreleaser)
+    alias(libs.plugins.spotless)
 }
 
 spotless {
     java {
         // Requires JDK 21+ to run. Gradle must be invoked with JDK 21 even though
         // the java toolchain targets JDK 17 for compilation.
-        googleJavaFormat("1.34.1")
+        googleJavaFormat(libs.versions.googleJavaFormat.get())
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()
@@ -38,16 +39,16 @@ repositories {
 }
 
 dependencies {
-    api(platform("org.testcontainers:testcontainers-bom:2.0.5"))
-    api("org.testcontainers:testcontainers")
+    api(platform(libs.testcontainers.bom))
+    api(libs.testcontainers)
 
-    testImplementation(platform("org.junit:junit-bom:6.1.1"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("org.testcontainers:testcontainers-junit-jupiter")
-    testImplementation("org.assertj:assertj-core:3.27.7")
-    testImplementation("com.tngtech.archunit:archunit-junit5:1.4.2")
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.archunit.junit5)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 java.toolchain {
@@ -63,19 +64,16 @@ java {
     withSourcesJar()
 }
 
-configure<PublishingExtension> {
+publishing {
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
-            groupId = groupId
-            artifactId = artifactId
-            description = "Test Container for Ory Hydra"
         }
         withType<MavenPublication> {
             pom {
                 packaging = "jar"
                 name.set("testcontainers-ory-hydra")
-                description.set("testcontainers ory hydra")
+                description.set("Testcontainers module for Ory Hydra")
                 url.set("https://github.com/ardetrick/testcontainers-ory-hydra")
                 inceptionYear.set("2023")
                 licenses {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+# Local + CI build cache for cacheable tasks (compilation, Spotless).
+org.gradle.caching=true
+# The configuration cache is deliberately NOT enabled: the JReleaser plugin is not
+# compatible with it (verified 2026-07 — jreleaserConfig fails under --configuration-cache),
+# and enabling it would break release tasks and the CI classpath smoke check.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,24 @@
+[versions]
+archunit = "1.4.2"
+assertj = "3.27.7"
+freefairLombok = "9.5.0"
+googleJavaFormat = "1.34.1"
+jreleaser = "1.25.0"
+junit = "6.1.1"
+spotless = "8.7.0"
+testcontainers = "2.0.5"
+
+[libraries]
+archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+testcontainers = { module = "org.testcontainers:testcontainers" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter" }
+
+[plugins]
+freefair-lombok = { id = "io.freefair.lombok", version.ref = "freefairLombok" }
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
Moves all dependency and plugin versions into gradle/libs.versions.toml, which Dependabot supports natively. The buildscript JGit force stays a literal (catalog accessors are unavailable in the buildscript block). Cleans the publishing config in passing — publishing {} accessor, no-op self-assignments dropped, POM description fixed — and enables the build cache; the configuration cache is deliberately left off because the JReleaser plugin fails under it (documented in gradle.properties). Verified locally: compile, unit tests, Spotless, jreleaserConfig smoke, and a staging publish; container tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)