### PR TITLE
chore: expand spotless to build scripts and misc files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,17 @@ spotless {
         // Requires JDK 21+ to run. Gradle must be invoked with JDK 21 even though
         // the java toolchain targets JDK 17 for compilation.
         googleJavaFormat(libs.versions.googleJavaFormat.get())
+        formatAnnotations()
         removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+    kotlinGradle {
+        ktlint()
+    }
+    // Whitespace hygiene for the non-code files nothing else formats.
+    format("misc") {
+        target("*.md", "*.yml", ".github/workflows/*.yml", "gradle/*.toml", ".gitignore")
         trimTrailingWhitespace()
         endWithNewline()
     }
@@ -99,7 +109,12 @@ publishing {
     }
     repositories {
         maven {
-            url = layout.buildDirectory.dir("staging-deploy").get().asFile.toURI()
+            url =
+                layout.buildDirectory
+                    .dir("staging-deploy")
+                    .get()
+                    .asFile
+                    .toURI()
         }
     }
 }


### PR DESCRIPTION
Adds formatAnnotations() to the Java steps, ktlint for the Gradle Kotlin scripts, and a whitespace-hygiene block for markdown/YAML/TOML. The codebase was already almost fully clean under the new rules — the only reformat is one chained-call wrap in the publishing block. Considered and skipped: licenseHeader, cleanthat, jackson YAML re-serialization, and ratchetFrom (unavailable under the JGit pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)