### PR TITLE
ci: adopt gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: build
         run: ./gradlew build --no-daemon
       # Catches buildscript classpath conflicts (e.g. the Spotless/JReleaser JGit collision,

--- a/.github/workflows/reference-app-compat.yml
+++ b/.github/workflows/reference-app-compat.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6
@@ -81,7 +82,8 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6


### PR DESCRIPTION
Replaces setup-java's coarse gradle cache with the Gradle-recommended setup-gradle action across both workflows: finer-grained caching with automatic cleanup and read-only caches on non-default branches, Gradle wrapper checksum validation (guarding the Dependabot wrapper-bump stream), and build/cache job summaries. Dependency-graph submission is left off — it requires contents: write and deserves a deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)