### PR TITLE
test: run the suite with parallel forks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,9 @@ java.toolchain {
 
 tasks.test {
     useJUnitPlatform()
+    // The suite is one-container-per-test and fully independent; parallel forks cut wall time
+    // on cache-miss runs (warm runs skip test execution entirely via the build cache).
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
 }
 
 java {


### PR DESCRIPTION
One-container-per-test and fully independent, so forked JVMs parallelize cleanly. Forced full execution: 51s serial → 34s parallel locally (all 59 tests green); CI benefits on cache-miss runs, warm runs already skip execution via the build cache. maxParallelForks = half the available processors, min 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)