### PR TITLE
fix: reject env overrides of Hydra's internal ports

### DIFF
--- a/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
+++ b/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
@@ -514,13 +514,27 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
     /**
      * Sets an environment variable that will be passed to the Hydra container.
      *
+     * <p>Hydra's internal ports are fixed to the image defaults (public 4444, admin 4445) — the
+     * exposed ports, wait strategy, and mapped-port accessors all assume them — so {@code
+     * SERVE_PUBLIC_PORT} and {@code SERVE_ADMIN_PORT} are rejected rather than allowed to present
+     * as a startup timeout.
+     *
      * @param key environment variable name
      * @param value environment variable value
      * @return this builder for chaining
+     * @throws IllegalArgumentException if {@code key} would change Hydra's internal ports
      */
     public Builder env(String key, String value) {
       Objects.requireNonNull(key, "key must not be null");
       Objects.requireNonNull(value, "value must not be null");
+      if (key.equals("SERVE_PUBLIC_PORT") || key.equals("SERVE_ADMIN_PORT")) {
+        throw new IllegalArgumentException(
+            key
+                + " is not supported: the container fixes Hydra's internal ports to the image"
+                + " defaults (public 4444, admin 4445); the exposed ports, wait strategy, and"
+                + " mapped-port accessors all assume them. Use the mapped ports for access"
+                + " instead.");
+      }
       this.env.put(key, value);
       return this;
     }
@@ -528,12 +542,15 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
     /**
      * Merges a map of environment variables that will be passed to the Hydra container.
      *
+     * <p>Applies the same validation as {@link #env(String, String)} to every entry.
+     *
      * @param env environment variables to add
      * @return this builder for chaining
+     * @throws IllegalArgumentException if any key would change Hydra's internal ports
      */
     public Builder env(Map<String, String> env) {
       Objects.requireNonNull(env, "env must not be null");
-      this.env.putAll(env);
+      env.forEach(this::env);
       return this;
     }
 

--- a/src/test/java/com/ardetrick/testcontainers/OryHydraContainerBuilderTest.java
+++ b/src/test/java/com/ardetrick/testcontainers/OryHydraContainerBuilderTest.java
@@ -7,6 +7,23 @@ import org.junit.jupiter.api.Test;
 class OryHydraContainerBuilderTest {
 
   @Test
+  void envRejectsInternalPortOverrides() {
+    var builder = OryHydraContainer.builder();
+    org.assertj.core.api.Assertions.assertThatIllegalArgumentException()
+        .isThrownBy(() -> builder.env("SERVE_ADMIN_PORT", "5555"))
+        .withMessageContaining("SERVE_ADMIN_PORT is not supported");
+    org.assertj.core.api.Assertions.assertThatIllegalArgumentException()
+        .isThrownBy(() -> builder.env("SERVE_PUBLIC_PORT", "5555"))
+        .withMessageContaining("SERVE_PUBLIC_PORT is not supported");
+    org.assertj.core.api.Assertions.assertThatIllegalArgumentException()
+        .isThrownBy(() -> builder.env(java.util.Map.of("SERVE_PUBLIC_PORT", "5555")))
+        .withMessageContaining("SERVE_PUBLIC_PORT is not supported");
+    // Other environment variables remain accepted.
+    builder.env("LOG_LEVEL", "debug");
+    builder.env(java.util.Map.of("STRATEGIES_ACCESS_TOKEN", "jwt"));
+  }
+
+  @Test
   void imageRejectsNull() {
     var builder = OryHydraContainer.builder();
     assertThatNullPointerException()


### PR DESCRIPTION
The container fixes Hydra's internal ports to the image defaults — the exposed ports, wait strategy, and mapped-port accessors all assume public 4444 and admin 4445 — so overriding SERVE_PUBLIC_PORT/SERVE_ADMIN_PORT via env() previously produced a baffling 30-second startup timeout. The builder now fails fast with an explanatory IllegalArgumentException; env(Map) applies the same validation per entry. Making the internal ports actually configurable was considered and rejected as speculative — fixed image-default ports are the standard Testcontainers pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)