### PR TITLE
ci: key the browser cache on the Playwright version alone

### DIFF
--- a/.github/workflows/reference-app-compat.yml
+++ b/.github/workflows/reference-app-compat.yml
@@ -39,12 +39,17 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+      # Key the browser cache on the Playwright version alone so unrelated dependency
+      # bumps in the reference app's catalog do not trigger a browser reinstall.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(grep -m1 '^playwright = ' gradle/libs.versions.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6
         with:
           path: /home/runner/.cache/ms-playwright
-          key: ms-playwright-chromium-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          key: ms-playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright Dependencies
         if: steps.setup-ms-playwright-cache.outputs.cache-hit != 'true'
         # Chromium only — the only browser the reference app's tests use.
@@ -83,12 +88,17 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+      # Key the browser cache on the Playwright version alone so unrelated dependency
+      # bumps in the reference app's catalog do not trigger a browser reinstall.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(grep -m1 '^playwright = ' reference-app/gradle/libs.versions.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6
         with:
           path: /home/runner/.cache/ms-playwright
-          key: ms-playwright-chromium-${{ runner.os }}-${{ hashFiles('reference-app/gradle/libs.versions.toml') }}
+          key: ms-playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright Dependencies
         if: steps.setup-ms-playwright-cache.outputs.cache-hit != 'true'
         working-directory: reference-app


### PR DESCRIPTION
The key uses the Playwright version from the reference app's catalog instead of hashing the whole file, so unrelated dependency bumps stop invalidating the browser cache. Keys also become readable in the cache UI (ms-playwright-chromium-Linux-1.61.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)