### PR TITLE
chore: bump default Hydra image to v26.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ var hydra = OryHydraContainer.builder()
 
 Using the `Builder` class, you can configure:
 
-* `image(DockerImageName)`: Override the Docker image (default: `oryd/hydra:v25.4.0`).
+* `image(DockerImageName)`: Override the Docker image (default: `oryd/hydra:v26.2.0`).
 * `urlsLogin(String)`: Set the login URL (`URLS_LOGIN`). Defaults to a non-resolvable sentinel host; the authorization-code flow helper intercepts login redirects by their challenge parameter, so the sentinel is never contacted.
 * `urlsConsent(String)`: Set the consent URL (`URLS_CONSENT`). Defaults to a non-resolvable sentinel host, as above.
 * `urlsSelfIssuer(String)`: Set the self-issuer URL (`URLS_SELF_ISSUER`).

--- a/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
+++ b/src/main/java/com/ardetrick/testcontainers/OryHydraContainer.java
@@ -27,7 +27,7 @@ public class OryHydraContainer extends GenericContainer<OryHydraContainer> {
 
   static final int HYDRA_ADMIN_PORT = 4445;
   static final int HYDRA_PUBLIC_PORT = 4444;
-  static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("oryd/hydra:v25.4.0");
+  static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("oryd/hydra:v26.2.0");
   static final String DEFAULT_DSN = "sqlite:///tmp/db.sqlite?_fk=true";
   static final String DEFAULT_SECRETS_SYSTEM = "testcontainers-ory-hydra-secret";
   // Non-resolvable sentinels: the authorization-code flow intercepts the login/consent redirects by


### PR DESCRIPTION
One release behind: v25.4.0 (2025-11-07) → v26.2.0 (2026-03-20), the latest. Release notes are internal fixes with nothing touching the admin challenge API or token endpoints; the migration fixes are exercised on every container start. Full suite passed locally against the new image (60 tests, 0 failures). Only the two live pin sites change — the DEFAULT_IMAGE constant and the README default line; the intentionally-old v2.3.0 examples are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)